### PR TITLE
Create NetworkPolicy to allow Ingress to RHSSO

### DIFF
--- a/roles/tackle/tasks/main.yml
+++ b/roles/tackle/tasks/main.yml
@@ -145,6 +145,12 @@
       retries: 30
       delay: 5
 
+    - name: "Create RHSSO Ingress Network Policy"
+      k8s:
+        state: present
+        definition: "{{ lookup('template', 'networkpolicy-rhsso-keycloak.yml.j2') }}"
+      when: rhsso_external_access | bool
+
 - name: "Setup PathFinder PostgreSQL PersistentVolume"
   k8s:
     state: present

--- a/roles/tackle/templates/customresource-rhsso-keycloak.yml.j2
+++ b/roles/tackle/templates/customresource-rhsso-keycloak.yml.j2
@@ -10,3 +10,6 @@ spec:
   instances: 1
   externalAccess:
     enabled: {{ rhsso_external_access }}
+  keycloakDeploymentSpec:
+    podlabels:
+      role: {{ rhsso_service_name }}

--- a/roles/tackle/templates/networkpolicy-rhsso-keycloak.yml.j2
+++ b/roles/tackle/templates/networkpolicy-rhsso-keycloak.yml.j2
@@ -1,0 +1,16 @@
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ rhsso_service_name }}-external
+  namespace: {{ app_namespace }}
+  labels:
+    app: {{ rhsso_service_name }}
+spec:
+  podSelector:
+    matchLabels:
+      role: {{ rhsso_service_name }}
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: {{ rhsso_port }}


### PR DESCRIPTION
When Deploying MTA 6 and Exposing RHSSO, a NetworkPolicy needs to be created manually to access the RHSSO UI.

This PR enables the operator to automatically create this NetPol when the user enables RHSSO to be exposed.