### PR TITLE
:seedling: Keep operator name the same

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -64,7 +64,7 @@ jobs:
           - konveyor/tackle2-ui
           - konveyor/tackle2-addon
           - konveyor/tackle2-addon-windup
-          - konveyor/operator
+          - konveyor/tackle2-operator
           - konveyor/tackle-pathfinder
           - konveyor/tackle-keycloak-init
     steps:


### PR DESCRIPTION
Even though the project has changed to konveyor/operator, the image we push to quay (at least for now) is konveyor/tackle2-operator.