### PR TITLE
:seedling: Update install script with debug output

### DIFF
--- a/hack/install-tackle.sh
+++ b/hack/install-tackle.sh
@@ -103,7 +103,7 @@ kubectl wait \
   tackles.tackle.konveyor.io/tackle \
 || kubectl get \
   --namespace konveyor-tackle \
-  -o yaml
+  -o yaml \
   tackles.tackle.konveyor.io/tackle # Print debug output when waiting failed
 
 # Now wait for all the tackle deployments

--- a/hack/install-tackle.sh
+++ b/hack/install-tackle.sh
@@ -70,7 +70,8 @@ spec:
   sourceNamespace: konveyor-tackle
 EOF
 # If on MacOS, need to install `brew install coreutils` to get `timeout`
-timeout 600s bash -c 'until kubectl get customresourcedefinitions.apiextensions.k8s.io tackles.tackle.konveyor.io; do sleep 30; done'
+timeout 600s bash -c 'until kubectl get customresourcedefinitions.apiextensions.k8s.io tackles.tackle.konveyor.io; do sleep 30; done' \
+|| kubectl get subscription --namespace konveyor-tackle -o yaml konveyor-operator # Print subscription details when timed out
 
 # Create, and wait for, tackle
 kubectl wait \

--- a/hack/install-tackle.sh
+++ b/hack/install-tackle.sh
@@ -104,7 +104,7 @@ kubectl wait \
 || kubectl get \
   --namespace konveyor-tackle \
   -o yaml \
-  tackles.tackle.konveyor.io/tackle # Print debug output when waiting failed
+  tackles.tackle.konveyor.io/tackle # Print tackle debug when timed out
 
 # Now wait for all the tackle deployments
 kubectl wait \
@@ -112,4 +112,10 @@ kubectl wait \
   --selector="app.kubernetes.io/part-of=tackle" \
   --for=condition=Available \
   --timeout=600s \
-  deployments.apps
+  deployments.apps \
+|| kubectl get \
+  --namespace konveyor-tackle \
+  --selector="app.kubernetes.io/part-of=tackle" \
+  --field-selector=status.phase!=Running  \
+  -o yaml \
+  pods # Print not running tackle pods when timed out

--- a/hack/install-tackle.sh
+++ b/hack/install-tackle.sh
@@ -100,7 +100,11 @@ kubectl wait \
   --namespace konveyor-tackle \
   --for=condition=Successful \
   --timeout=600s \
-  tackles.tackle.konveyor.io/tackle
+  tackles.tackle.konveyor.io/tackle \
+|| kubectl get \
+  --namespace konveyor-tackle \
+  -o yaml
+  tackles.tackle.konveyor.io/tackle # Print debug output when waiting failed
 
 # Now wait for all the tackle deployments
 kubectl wait \


### PR DESCRIPTION
The Tackle/Konveyor install script has few waiting loops checking the installation progress/completeness. Based on last few errors, adding an output with tackle details when waiting loop timeouted to help with debugging CI errors directly in github workflow execution.

Example with recent installation error:
```
...
error: timed out waiting for the condition on tackles/tackle
...
status:
  conditions:
  - lastTransitionTime: "2023-07-24T08:51:07Z"
    message: ""
    reason: ""
    status: "False"
    type: Successful
  - ansibleResult:
      changed: 0
      completion: 2023-07-24T09:05:50.668218
      failures: 1
      ok: 14
      skipped: 48
    lastTransitionTime: "2023-07-24T09:05:51Z"
    message: |
      The task includes an option with an undefined variable. The error was: 'hub_seed_configmap_name' is undefined

      The error appears to be in '/opt/ansible/roles/tackle/tasks/main.yml': line 406, column 3, but may
      be elsewhere in the file depending on the exact syntax problem.

      The offending line appears to be:


      - name: "Setup Hub API Deployment"
        ^ here
    reason: Failed
    status: "False"
    type: Failure
...
```

Related to https://github.com/konveyor/operator/issues/133