### PR TITLE
:seedling: use previous version when creating release

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -42,6 +42,7 @@ jobs:
       - uses: konveyor/release-tools/create-release@main
         with:
           version: ${{ inputs.version }}
+          prev_version: ${{ inputs.previous_version }}
           repository: konveyor/java-analyzer-bundle
           ref: ${{ inputs.branch }}
           github_token: ${{ secrets.GH_TOKEN }}
@@ -54,6 +55,7 @@ jobs:
       - uses: konveyor/release-tools/create-release@main
         with:
           version: ${{ inputs.version }}
+          prev_version: ${{ inputs.previous_version }}
           repository: konveyor/analyzer-lsp
           ref: ${{ inputs.branch }}
           github_token: ${{ secrets.GH_TOKEN }}
@@ -66,6 +68,7 @@ jobs:
       - uses: konveyor/release-tools/create-release@main
         with:
           version: ${{ inputs.version }}
+          prev_version: ${{ inputs.previous_version }}
           repository: konveyor/windup-shim
           ref: ${{ inputs.branch }}
           github_token: ${{ secrets.GH_TOKEN }}
@@ -78,6 +81,7 @@ jobs:
       - uses: konveyor/release-tools/create-release@main
         with:
           version: ${{ inputs.version }}
+          prev_version: ${{ inputs.previous_version }}
           repository: konveyor/tackle2-addon-analyzer
           ref: ${{ inputs.branch }}
           github_token: ${{ secrets.GH_TOKEN }}
@@ -111,6 +115,7 @@ jobs:
       - uses: konveyor/release-tools/create-release@main
         with:
           version: ${{ inputs.version }}
+          prev_version: ${{ inputs.previous_version }}
           repository: ${{ matrix.projects.repo }}
           ref: ${{ inputs.branch }}
           github_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -19,6 +19,7 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
 
   build-operator:
+    needs: check-title
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -32,6 +33,7 @@ jobs:
     - run: make bundle bundle-build bundle-push
 
   operator-install:
+    needs: build-bundle
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Since we usually provide the "previous_version" as input to the workflow, we should just pass it along to the create release action to prevent us from having to be clever.