### PR TITLE
:sparkles: Pass proxy configuration through to Hub pod

### DIFF
--- a/roles/tackle/defaults/main.yml
+++ b/roles/tackle/defaults/main.yml
@@ -14,6 +14,9 @@ feature_pathfinder: true
 # Environment
 openshift_cluster: false
 image_pull_policy: "Always"
+http_proxy: "{{ lookup('env', 'HTTP_PROXY') }}"
+https_proxy: "{{ lookup('env', 'HTTPS_PROXY') }}"
+no_proxy: "{{ lookup('env', 'NO_PROXY') }}"
 
 # Components
 hub_image_fqin: "{{ lookup('env', 'RELATED_IMAGE_TACKLE_HUB') }}"

--- a/roles/tackle/templates/deployment-hub.yml.j2
+++ b/roles/tackle/templates/deployment-hub.yml.j2
@@ -169,6 +169,18 @@ spec:
             - name: CACHE_PATH
               value: "{{ cache_mount_path }}"
 {% endif %}
+{% if http_proxy|length >0 %}
+            - name: HTTP_PROXY
+              value: {{ http_proxy }}
+{% endif %}
+{% if https_proxy|length >0 %}
+            - name: HTTPS_PROXY
+              value: {{ https_proxy }}
+{% endif %}
+{% if no_proxy|length >0 %}
+            - name: NO_PROXY
+              value: {{ no_proxy }}
+{% endif %}
           ports:
             - containerPort: {{ hub_port }}
               protocol: TCP


### PR DESCRIPTION
Intended to resolve https://issues.redhat.com/browse/MTA-849