### PR TITLE
:ghost: target specific variables not working

### DIFF
--- a/.github/actions/install-konveyor/action.yml
+++ b/.github/actions/install-konveyor/action.yml
@@ -24,7 +24,6 @@ runs:
       OPERATOR_BUNDLE_IMAGE: ${{ inputs.bundle_image }}
       NAMESPACE: ${{ inputs.namespace }}
       TACKLE_CR: ${{ inputs.tackle_cr }}
-    run: |
-      make install-konveyor
+    run: make install-konveyor
     working-directory: ${{ github.action_path }}/../../..
     shell: bash

--- a/.github/actions/make-bundle/action.yml
+++ b/.github/actions/make-bundle/action.yml
@@ -59,7 +59,7 @@ runs:
       [ -n "${{ inputs.addon_admin }}" ] && OPTS+=" --set images.addon_admin=${{ inputs.addon_admin }}"
       [ -n "${{ inputs.addon_analyzer }}" ] && OPTS+=" --set images.addon_analyzer=${{ inputs.addon_analyzer }}"
       HELM_TEMPLATE_OPTS="${OPTS}" make bundle
-      git diff ./bundle
+      cat ./bundle/manifests/konveyor-operator.clusterserviceversion.yaml
       BUNDLE_IMG="${{ inputs.operator_bundle }}" make bundle-build
     working-directory: ${{ github.action_path }}/../../..
     shell: bash


### PR DESCRIPTION
remove the `deploy-olm` target entirely in favor of the `install` and `uninstall` targets for development.