### PR TITLE
:bug: Addon memory request and limit match.

### DIFF
--- a/roles/tackle/defaults/main.yml
+++ b/roles/tackle/defaults/main.yml
@@ -163,7 +163,7 @@ analyzer_service_name: "{{ app_name }}-{{ analyzer_name }}-{{ analyzer_component
 analyzer_container_limits_cpu: "1"
 analyzer_container_limits_memory: "4Gi"
 analyzer_container_requests_cpu: "1"
-analyzer_container_requests_memory: "2Gi"
+analyzer_container_requests_memory: "4Gi"
 
 cache_name: "cache"
 cache_data_volume_size: "100Gi"


### PR DESCRIPTION
Deploying the pod with request = limit should be a good (incremental) step towards preventing OOM kills.
My memory profiling suggests that 4Gi is a good number for our TestApp.  Although, I can run analysis on the TestApp using 2Gi/2Gi just fine (though memory peaks at 1.9Gi) on my minikube but Pranav reports that he cannot.
We should still follow up with passing -Xmx=80% of limit to the Java provider.

 IMHO, 4Gi is much higher than I would have expected for the analyzer.  This means that when running on most personal, single node clusters (like minikube), we will only be able to analyze a few applications in parallel.