### PR TITLE
:sparkles: Add configuration switch for volume expansion

### DIFF
--- a/roles/tackle/defaults/main.yml
+++ b/roles/tackle/defaults/main.yml
@@ -17,6 +17,9 @@ http_proxy: "{{ lookup('env', 'HTTP_PROXY') }}"
 https_proxy: "{{ lookup('env', 'HTTPS_PROXY') }}"
 no_proxy: "{{ lookup('env', 'NO_PROXY') }}"
 
+# PVC Handling
+expand_volume_sizes: true
+
 # Components
 hub_image_fqin: "{{ lookup('env', 'RELATED_IMAGE_TACKLE_HUB') }}"
 hub_component_name: "hub"

--- a/roles/tackle/tasks/main.yml
+++ b/roles/tackle/tasks/main.yml
@@ -272,6 +272,19 @@
       retries: 30
       delay: 5
 
+- name: "Retrieve Hub API Database PersistentVolumeClaim"
+  k8s_info:
+    api_version: v1
+    kind: PersistentVolumeClaim
+    name: "{{ hub_database_volume_claim_name }}"
+    namespace: "{{ app_namespace }}"
+  register: hub_database
+
+- name: "Set database volume request size based on existing size"
+  when: hub_database.resources | length > 0 and not expand_volume_sizes
+  set_fact:
+    hub_database_volume_size: " {{ (hub_database.resources | first).spec.resources.requests.storage }}"
+
 - name: "Setup Hub API Database PersistentVolumeClaim"
   k8s:
     state: present


### PR DESCRIPTION
This adds a new configuration parameter `expand_volume_sizes` which defaults to `true`. Specifically this PR addresses the issue of raising the `hub_database_volume_size` between versions and impacting upgrades where a storageclass doesn't support volume expansion. If the user sets this to false we will leave the storage requests size of the hub volume alone.