### PR TITLE
:book: Update OLM version in installation-macos.md

### DIFF
--- a/docs/installation-macos.md
+++ b/docs/installation-macos.md
@@ -16,7 +16,7 @@ podman machine start
 3. Install ingress addon
 `minikube addons enable ingress`
 4. Install OLM to manage Konveyor operator
-`curl -sL https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.21.2/install.sh | bash -s v0.21.2`
+`curl -sL https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.27.0/install.sh | bash -s v0.27.0`
 5. Install Konveyor operator
 `kubectl create -f https://operatorhub.io/install/konveyor-operator.yaml`
 6. Verify if the Konveyor operator pod is running or not


### PR DESCRIPTION
v0.21.2 fails on Apple Silicon ARM due to this https://github.com/operator-framework/operator-lifecycle-manager/issues/2823#issuecomment-1468421055

A minimum of 0.24.0 is required, I managed to install it on my machine with 0.27.0