### PR TITLE
:ghost: Fix build failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY tools/upgrades/jwt.sh /usr/local/bin/jwt.sh
 RUN dnf -y install openssl && dnf clean all
 RUN echo -e "[centos8-appstream]" \
  "\nname = centos8-appstream" \
- "\nbaseurl = http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/" \
+ "\nbaseurl = https://vault.centos.org/8-stream/AppStream/x86_64/os/" \
  "\nenabled = 1" \
  "\ngpgcheck = 0" > /etc/yum.repos.d/centos.repo
 RUN dnf -y module enable postgresql:15 && dnf -y install postgresql && dnf clean all


### PR DESCRIPTION
CentOS Stream 8 is EOL. For the short term we can still get packages from the CentOS vault.