### PR TITLE
:bug: Move index Dockerfile generation to pre_build_cmd

### DIFF
--- a/.github/workflows/march-image-build-push.yml
+++ b/.github/workflows/march-image-build-push.yml
@@ -44,23 +44,15 @@ jobs:
         quay_publish_token: ${{ secrets.QUAY_PUBLISH_TOKEN }}
         ref: ${{ github.ref }}
 
-    - name: Checkout PR branch
-      uses: actions/checkout@v2
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
-
-    - name: Generate Operator Index Dockerfile
-      run: |
-        CONTAINER_RUNTIME=podman \
-        CATALOG_IMG=quay.io/konveyor/tackle2-operator-index:latest \
-        BUNDLE_IMG=quay.io/konveyor/tackle2-operator-bundle:latest \
-        make catalog-index
-      if: ${{ github.ref == 'refs/heads/main' }}
-
     - name: Build Operator Index
       uses: konveyor/release-tools/build-push-quay@main
       with:
         architectures: "amd64 arm64"
+        pre_build_cmd: |
+          CONTAINER_RUNTIME=podman \
+          CATALOG_IMG=quay.io/konveyor/tackle2-operator-index:latest \
+          BUNDLE_IMG=quay.io/konveyor/tackle2-operator-bundle:latest \
+          make catalog-index
         containerfile: "./index.Dockerfile"
         image_name: "tackle2-operator-index"
         image_namespace: "konveyor"


### PR DESCRIPTION
build-push-quay is doing a clean checkout so what we do before has no bearing.