### PR TITLE
:ghost: Add CSV annotations

### DIFF
--- a/bundle/manifests/konveyor-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/konveyor-operator.clusterserviceversion.yaml
@@ -24,6 +24,16 @@ metadata:
     description: Konveyor is an open-source application modernization platform that
       helps organizations safely and predictably modernize applications to Kubernetes
       at scale.
+    features.operators.openshift.io/cnf: "false"
+    features.operators.openshift.io/cni: "false"
+    features.operators.openshift.io/csi: "false"
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/proxy-aware: "true"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
     olm.skipRange: '>=0.0.0 <99.0.0'
     operatorframework.io/initialization-resource: |-
       {

--- a/helm/templates/olm/konveyor-operator.clusterserviceversion.yaml
+++ b/helm/templates/olm/konveyor-operator.clusterserviceversion.yaml
@@ -11,6 +11,16 @@ metadata:
     description: Konveyor is an open-source application modernization platform that
       helps organizations safely and predictably modernize applications to Kubernetes
       at scale.
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/proxy-aware: "true"
+    features.operators.openshift.io/cnf: "false"
+    features.operators.openshift.io/cni: "false"
+    features.operators.openshift.io/csi: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
     olm.skipRange: '>=0.0.0 <{{ .Values.version }}'
     operatorframework.io/initialization-resource: |-
       {


### PR DESCRIPTION
I am not certain about this one. Can others weigh in:

```
features.operators.openshift.io/proxy-aware

Specify whether an Operator supports running on a cluster behind a proxy by accepting the standard HTTP_PROXY and HTTPS_PROXY proxy environment variables. If applicable, the Operator passes this information to the workload it manages (operands).
```