### PR TITLE
:seedling: double the ttl on operator image

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -6,6 +6,9 @@ on:
       - main
       - 'release-*.*'
 
+env:
+  IMG: ttl.sh/konveyor-operator-${{ github.sha }}:2h
+
 jobs:
   detect-changes:
     runs-on: ubuntu-latest
@@ -40,8 +43,6 @@ jobs:
   build-operator:
     needs: detect-changes
     runs-on: ubuntu-latest
-    env:
-      IMG: ttl.sh/konveyor-operator-${{ github.sha }}:1h
     steps:
     - uses: actions/checkout@v3
     - run: make docker-build docker-push
@@ -50,4 +51,4 @@ jobs:
     needs: build-operator
     uses: konveyor/ci/.github/workflows/global-ci-bundle.yml@main
     with:
-      operator: ttl.sh/konveyor-operator-${{ github.sha }}:1h
+      operator: ${{ env.IMG }}


### PR DESCRIPTION
This should make "rerunning failed" tasks in workflows less likely to fail simply because the image didn't exist anymore.