### PR TITLE
:bug: Correct catalog source image name

### DIFF
--- a/konveyor-operator-catalog.yaml
+++ b/konveyor-operator-catalog.yaml
@@ -7,7 +7,7 @@ spec:
   displayName: Konveyor Operator
   publisher: Konveyor
   sourceType: grpc
-  image: quay.io/jmontleon/tackle2-operator-index:latest
+  image: quay.io/konveyor/tackle2-operator-index:latest
   updateStrategy:
     registryPoll:
       interval: 10m


### PR DESCRIPTION
This was accidentally updated by a change for testing that slipped in.