### PR TITLE
:sparkles: Add setting to disable analysis archiver

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Name | Default | Description
 --- | --- | ---
 feature_auth_required | true | Enable keycloak auth or false (single user/noauth)
 feature_isolate_namespace | true | Enable namespace isolation via network policies
+feature_analysis_archiver | true | If enabled, automatically archives old analysis reports when a new one is created
 rwx_supported: | true | Whether or not RWX volumes are supported in the cluster
 hub_database_volume_size | 5Gi | Size requested for Hub database volume
 hub_bucket_volume_size | 100gi | Size requested for Hub bucket volume

--- a/roles/tackle/defaults/main.yml
+++ b/roles/tackle/defaults/main.yml
@@ -9,6 +9,7 @@ app_version: "{{ lookup('env', 'VERSION') }}"
 feature_auth_required: "{{ false if app_profile == 'konveyor' else true }}"
 feature_auth_type: keycloak
 feature_isolate_namespace: true
+feature_analysis_archiver: true
 
 # Environment
 openshift_cluster: false

--- a/roles/tackle/templates/deployment-hub.yml.j2
+++ b/roles/tackle/templates/deployment-hub.yml.j2
@@ -178,6 +178,13 @@ spec:
             - name: NO_PROXY
               value: {{ no_proxy }}
 {% endif %}
+{% if feature_analysis_archiver|bool %}
+            - name: ANALYSIS_ARCHIVER_ENABLED
+              value: "true"
+{% else %}
+            - name: ANALYSIS_ARCHIVER_ENABLED
+              value: "false"
+{% endif %}
           ports:
             - containerPort: {{ hub_port }}
               protocol: TCP


### PR DESCRIPTION
This is necessary for Kai to harvest historical data from the hub

Related to konveyor/tackle2-hub/pull/631