### PR TITLE
:bug: discovery should run at default priority. (#346)

### DIFF
--- a/roles/tackle/templates/customresource-addon-language-discovery.yml.j2
+++ b/roles/tackle/templates/customresource-addon-language-discovery.yml.j2
@@ -30,6 +30,5 @@ metadata:
   labels:
     konveyor.io/discovery: "language"
 spec:
-  priority: 10
   data:
     source: language-discovery

--- a/roles/tackle/templates/customresource-addon-tech-discovery.yml.j2
+++ b/roles/tackle/templates/customresource-addon-tech-discovery.yml.j2
@@ -111,7 +111,6 @@ metadata:
   labels:
     konveyor.io/discovery: "technology"
 spec:
-  priority: 10
   dependencies: [ {{ language_discovery_name }} ]
   data:
     mode:


### PR DESCRIPTION
system generated tasks should run at default priority (0).