### PR TITLE
:sparkles: Add support for deploying kai

### DIFF
--- a/bundle/manifests/konveyor-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/konveyor-operator.clusterserviceversion.yaml
@@ -103,7 +103,7 @@ metadata:
     categories: Modernization & Migration
     certified: "false"
     containerImage: quay.io/konveyor/tackle2-operator:latest
-    createdAt: "2024-07-24T20:21:03Z"
+    createdAt: "2024-08-19T17:42:17Z"
     description: Konveyor is an open-source application modernization platform that
       helps organizations safely and predictably modernize applications to Kubernetes
       at scale.
@@ -292,6 +292,8 @@ spec:
                   value: quay.io/konveyor/generic-external-provider:latest
                 - name: RELATED_IMAGE_PROVIDER_JAVA
                   value: quay.io/konveyor/java-external-provider:latest
+                - name: RELATED_IMAGE_KAI
+                  value: quay.io/konveyor/kai:latest
                 image: quay.io/konveyor/tackle2-operator:latest
                 imagePullPolicy: Always
                 livenessProbe:
@@ -486,4 +488,6 @@ spec:
     name: provider-generic
   - image: quay.io/konveyor/java-external-provider:latest
     name: provider-java
+  - image: quay.io/konveyor/kai:latest
+    name: kai
   version: 99.0.0

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -55,6 +55,8 @@ spec:
           value: {{ .Values.images.provider_generic }}
         - name: RELATED_IMAGE_PROVIDER_JAVA
           value: {{ .Values.images.provider_java }}
+        - name: RELATED_IMAGE_KAI
+          value: {{ .Values.images.kai }}
         name: tackle-operator
         image: {{ .Values.images.operator }}
         imagePullPolicy: Always

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -22,3 +22,4 @@ images:
   addon_discovery: quay.io/konveyor/tackle2-addon-discovery:latest
   provider_generic: quay.io/konveyor/generic-external-provider:latest
   provider_java: quay.io/konveyor/java-external-provider:latest
+  kai: quay.io/konveyor/kai:latest

--- a/roles/tackle/defaults/main.yml
+++ b/roles/tackle/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
+
+
 # App defaults
 app_name: "{{ lookup('env', 'APP_NAME') or 'tackle' }}"
 app_namespace: "{{ lookup('env', 'WATCH_NAMESPACE') or 'konveyor-tackle' }}"
@@ -219,3 +221,28 @@ rhsso_tls_enabled: true
 rhsso_port: "{{ '8443' if rhsso_tls_enabled | bool else '8080' }}"
 rhsso_proto: "{{ 'https' if rhsso_tls_enabled | bool else 'http' }}"
 rhsso_url: "{{ rhsso_proto }}://keycloak.{{ app_namespace }}.svc:{{ rhsso_port }}"
+
+
+# Kai-related variables
+experimental_deploy_kai: false
+
+kai_fqin: "{{ lookup('env', 'RELATED_IMAGE_KAI') }}"
+
+kai_api_key_secret_name: kai-api-keys
+kai_jwt_secret_name: kai-jwt-secret
+kai_bam_secret_key: genai_key
+kai_openai_secret_base_key: api_base
+kai_openai_secret_api_key: api_key
+kai_log_level: info
+kai_enable_demo_mode: "false"
+kai_enable_trace: "true"
+kai_model_provider: "ChatIBMGenAI"
+kai_model_id: "mistralai/mixtral-8x7b-instruct-v01"
+
+kai_hub_importer_args: "-k"
+
+kai_database_image_fqin: "{{ keycloak_database_image_fqin }}"
+kai_database_secret_name: kai-db-secret
+kai_database_volume_size: "10Gi"
+kai_database_volume_claim_name: "{{ hub_service_name }}-kai-database-volume-claim"
+kai_database_address: kai-db.{{ app_namespace }}.svc

--- a/roles/tackle/defaults/main.yml
+++ b/roles/tackle/defaults/main.yml
@@ -239,7 +239,7 @@ kai_enable_trace: "true"
 kai_model_provider: "ChatIBMGenAI"
 kai_model_id: "mistralai/mixtral-8x7b-instruct-v01"
 
-kai_hub_importer_args: "-k"
+kai_hub_importer_args: ""
 
 kai_database_image_fqin: "{{ keycloak_database_image_fqin }}"
 kai_database_secret_name: kai-db-secret

--- a/roles/tackle/tasks/kai.yml
+++ b/roles/tackle/tasks/kai.yml
@@ -1,0 +1,124 @@
+---
+
+- name: Verify API key secret is defined
+  k8s_info:
+    api_version: v1
+    kind: Secret
+    name: "{{ kai_api_key_secret_name }}"
+    namespace: "{{ app_namespace }}"
+  register: kai_api_key_secret_status
+
+- when: (kai_api_key_secret_status.resources|length) > 0
+  block:
+    - name: Check if JWT token secret is defined
+      k8s_info:
+        api_version: v1
+        kind: Secret
+        name: "{{ kai_jwt_secret_name }}"
+        namespace: "{{ app_namespace }}"
+      register: kai_jwt_secret_status
+
+    - name: Check if DB secret is defined
+      k8s_info:
+        api_version: v1
+        kind: Secret
+        name: "{{ kai_database_secret_name }}"
+        namespace: "{{ app_namespace }}"
+      register: kai_db_secret_status
+
+    - name: Generate random password for Postgres
+      set_fact:
+        pg_password: "{{ lookup('password', '/dev/null length=32 chars=ascii_letters,digits') }}"
+      when: (kai_db_secret_status.resources|length) == 0
+
+    - name: Create DB secret
+      k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: "{{ kai_database_secret_name }}"
+            namespace: "{{ app_namespace }}"
+          stringData:
+            POSTGRES_HOST: "{{ kai_database_address }}"
+            POSTGRES_DB: kai
+            POSTGRES_PASSWORD: "{{ pg_password }}"
+            POSTGRES_USER: kai
+      when: (kai_db_secret_status.resources|length) == 0
+
+    - name: Decode pg_password from secret
+      set_fact:
+        pg_password: "{{ kai_db_secret_status.resources.0.data.POSTGRES_PASSWORD | b64decode }}"
+      when: (kai_db_secret_status.resources|length) > 0
+
+    - name: Retrieve Hub Secret
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: Secret
+        name: "{{ hub_secret_name }}"
+        namespace: "{{ app_namespace }}"
+      register: hub_secret
+
+    - name: Set Hub key
+      set_fact:
+        hub_key: "{{ hub_secret.resources[0].data.addon_token | b64decode }}"
+    - name: Generate JWT token for Kai
+      command: |
+        /usr/local/bin/jwt.sh {{ hub_key }}
+      register: kai_jwt
+      when: (kai_jwt_secret_status.resources|length) == 0
+      changed_when: (kai_jwt_secret_status.resources|length) == 0
+
+    - name: Create JWT token secret
+      k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: "{{ kai_jwt_secret_name }}"
+            namespace: "{{ app_namespace }}"
+          stringData:
+            jwt: "{{ kai_jwt.stdout }}"
+      when: (kai_jwt_secret_status.resources|length) == 0
+
+    - name: Create KAI ConfigMap
+      k8s:
+        state: present
+        template: kai/kai-config.yaml.j2
+
+    - name: Deploy KAI DB
+      k8s:
+        state: present
+        template: kai/kai-db-deployment.yaml.j2
+
+    - name: Create KAI DB Service
+      k8s:
+        state: present
+        template: kai/kai-db-service.yaml.j2
+
+    - name: Create KAI DB PersistentVolumeClaim
+      k8s:
+        state: present
+        template: kai/kai-db-pvc.yaml.j2
+
+    - name: Deploy KAI API service
+      k8s:
+        state: present
+        template: kai/kai-api-deployment.yaml.j2
+
+    - name: Create KAI API Service
+      k8s:
+        state: present
+        template: kai/kai-api-service.yaml.j2
+
+    - name: Deploy KAI Hub Importer
+      k8s:
+        state: present
+        template: kai/kai-importer-deployment.yaml.j2
+
+    - name: Create KAI Hub Importer Service
+      k8s:
+        state: present
+        template: kai/kai-importer-service.yaml.j2

--- a/roles/tackle/tasks/kai.yml
+++ b/roles/tackle/tasks/kai.yml
@@ -41,15 +41,15 @@
             name: "{{ kai_database_secret_name }}"
             namespace: "{{ app_namespace }}"
           stringData:
-            POSTGRES_HOST: "{{ kai_database_address }}"
-            POSTGRES_DB: kai
-            POSTGRES_PASSWORD: "{{ pg_password }}"
-            POSTGRES_USER: kai
+            POSTGRESQL_HOST: "{{ kai_database_address }}"
+            POSTGRESQL_DATABASE: kai
+            POSTGRESQL_PASSWORD: "{{ pg_password }}"
+            POSTGRESQL_USER: kai
       when: (kai_db_secret_status.resources|length) == 0
 
     - name: Decode pg_password from secret
       set_fact:
-        pg_password: "{{ kai_db_secret_status.resources.0.data.POSTGRES_PASSWORD | b64decode }}"
+        pg_password: "{{ kai_db_secret_status.resources.0.data.POSTGRESQL_PASSWORD | b64decode }}"
       when: (kai_db_secret_status.resources|length) > 0
 
     - name: Retrieve Hub Secret

--- a/roles/tackle/tasks/main.yml
+++ b/roles/tackle/tasks/main.yml
@@ -732,3 +732,8 @@
   when:
     - (pathfinder_delete_db_volume|bool)
     - (pathfinder_pod.resources|length) == 0
+
+- name: Run kai tasks
+  when:
+    - (experimental_deploy_kai|bool)
+  include_tasks: kai.yml

--- a/roles/tackle/tasks/main.yml
+++ b/roles/tackle/tasks/main.yml
@@ -734,6 +734,5 @@
     - (pathfinder_pod.resources|length) == 0
 
 - name: Run kai tasks
-  when:
-    - (experimental_deploy_kai|bool)
-  include_tasks: kai.yml
+  when: experimental_deploy_kai
+  import_tasks: kai.yml

--- a/roles/tackle/templates/kai/kai-api-deployment.yaml.j2
+++ b/roles/tackle/templates/kai/kai-api-deployment.yaml.j2
@@ -1,0 +1,83 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kai-api
+  namespace: "{{ app_namespace }}"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kai-api
+  template:
+    metadata:
+      labels:
+        app: kai-api
+    spec:
+      containers:
+        - name: kai-api
+          image: "{{ kai_fqin }}"
+          ports:
+            - containerPort: 8080
+          env:
+            - name: POSTGRES_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ kai_db_secret_name }}"
+                  key: POSTGRES_HOST
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ kai_db_secret_name }}"
+                  key: POSTGRES_DB
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ kai_db_secret_name }}"
+                  key: POSTGRES_PASSWORD
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ kai_db_secret_name }}"
+                  key: POSTGRES_USER
+            - name: DEMO_MODE
+              value: "False"
+            - name: HUB_URL
+              value: "{{ hub_url }}"
+            - name: IMPORTER_ARGS
+              value: ""
+            - name: LOGLEVEL
+              value: "info"
+            - name: NUM_WORKERS
+              value: "8"
+            - name: USE_HUB_IMPORTER
+              value: "True"
+{% if kai_api_key_secret_status.resources.0.data[kai_bam_secret_key]|default(false) %}
+            - name: GENAI_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ kai_api_key_secret_name }}"
+                  key: "{{ kai_bam_secret_key }}"
+{% endif %}
+{% if kai_api_key_secret_status.resources.0.data[kai_openai_secret_base_key]|default(false) %}
+            - name: OPENAI_API_BASE
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ kai_api_key_secret_name }}"
+                  key: "{{ kai_openai_secret_base_key }}"
+{% endif %}
+{% if kai_api_key_secret_status.resources.0.data[kai_openai_secret_api_key]|default(false) %}
+            - name: OPENAI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ kai_api_key_secret_name }}"
+                  key: "{{ kai_openai_secret_api_key }}"
+{% endif %}
+          volumeMounts:
+            - name: config-volume
+              mountPath: /podman_compose/kai-config.toml
+              subPath: kai-config.toml
+      volumes:
+        - name: config-volume
+          configMap:
+            name: "kai-config"

--- a/roles/tackle/templates/kai/kai-api-deployment.yaml.j2
+++ b/roles/tackle/templates/kai/kai-api-deployment.yaml.j2
@@ -20,26 +20,26 @@ spec:
           ports:
             - containerPort: 8080
           env:
-            - name: POSTGRES_HOST
+            - name: POSTGRESQL_HOST
               valueFrom:
                 secretKeyRef:
                   name: "{{ kai_db_secret_name }}"
-                  key: POSTGRES_HOST
-            - name: POSTGRES_DB
+                  key: POSTGRESQL_HOST
+            - name: POSTGRESQL_DATABASE
               valueFrom:
                 secretKeyRef:
                   name: "{{ kai_db_secret_name }}"
-                  key: POSTGRES_DB
-            - name: POSTGRES_PASSWORD
+                  key: POSTGRESQL_DB
+            - name: POSTGRESQL_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: "{{ kai_db_secret_name }}"
-                  key: POSTGRES_PASSWORD
-            - name: POSTGRES_USER
+                  key: POSTGRESQL_PASSWORD
+            - name: POSTGRESQL_USER
               valueFrom:
                 secretKeyRef:
                   name: "{{ kai_db_secret_name }}"
-                  key: POSTGRES_USER
+                  key: POSTGRESQL_USER
             - name: DEMO_MODE
               value: "False"
             - name: HUB_URL

--- a/roles/tackle/templates/kai/kai-api-service.yaml.j2
+++ b/roles/tackle/templates/kai/kai-api-service.yaml.j2
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kai-api
+  namespace: "{{ app_namespace }}"
+spec:
+  selector:
+    app: kai-api
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080

--- a/roles/tackle/templates/kai/kai-config.yaml.j2
+++ b/roles/tackle/templates/kai/kai-config.yaml.j2
@@ -1,0 +1,37 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "kai-config"
+  namespace: "{{ app_namespace }}"
+data:
+  kai-config.toml: |
+    # TODO: Make all these configurable via ansible
+    log_level = "{{ kai_log_level }}"
+    file_log_level = "debug"
+    log_dir = "/podman_compose/logs"
+    demo_mode = {{ kai_enable_demo_mode }}
+    trace_enabled = {{ kai_enable_trace }}
+
+    solution_consumers = ["diff_only", "llm_summary"]
+
+    [incident_store]
+    solution_detectors = "naive"
+    solution_producers = "text_only"
+
+    [incident_store.args]
+    provider = "postgresql"
+    host = "kai-db"
+    database = "kai"
+    user = "kai"
+    # TODO: This may need to be envvar only
+    password = "{{ pg_password }}"
+
+    [models]
+    provider = "{{ kai_model_provider }}"
+
+    [models.args]
+    model_id = "{{ kai_model_id }}"
+
+    [embeddings]
+    todo = true

--- a/roles/tackle/templates/kai/kai-db-deployment.yaml.j2
+++ b/roles/tackle/templates/kai/kai-db-deployment.yaml.j2
@@ -1,0 +1,42 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kai-db
+  namespace: "{{ app_namespace }}"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kai-db
+  template:
+    metadata:
+      labels:
+        app: kai-db
+    spec:
+      containers:
+        - name: kai-db
+          image: "{{ kai_database_image_fqin }}"
+          env:
+            - name: POSTGRESQL_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ kai_db_secret_name }}"
+                  key: POSTGRES_DB
+            - name: POSTGRESQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ kai_db_secret_name }}"
+                  key: POSTGRES_PASSWORD
+            - name: POSTGRESQL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ kai_db_secret_name }}"
+                  key: POSTGRES_USER
+          volumeMounts:
+            - mountPath: /var/lib/postgresql/data
+              name: kai-db-data
+      volumes:
+        - name: kai-db-data
+          persistentVolumeClaim:
+            claimName: "{{ kai_database_volume_claim_name }}"

--- a/roles/tackle/templates/kai/kai-db-deployment.yaml.j2
+++ b/roles/tackle/templates/kai/kai-db-deployment.yaml.j2
@@ -22,17 +22,17 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: "{{ kai_db_secret_name }}"
-                  key: POSTGRES_DB
+                  key: POSTGRESQL_DATABASE
             - name: POSTGRESQL_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: "{{ kai_db_secret_name }}"
-                  key: POSTGRES_PASSWORD
+                  key: POSTGRESQL_PASSWORD
             - name: POSTGRESQL_USER
               valueFrom:
                 secretKeyRef:
                   name: "{{ kai_db_secret_name }}"
-                  key: POSTGRES_USER
+                  key: POSTGRESQL_USER
           volumeMounts:
             - mountPath: /var/lib/postgresql/data
               name: kai-db-data

--- a/roles/tackle/templates/kai/kai-db-pvc.yaml.j2
+++ b/roles/tackle/templates/kai/kai-db-pvc.yaml.j2
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "{{ kai_database_volume_claim_name }}"
+  namespace: "{{ app_namespace }}"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: "{{ kai_database_volume_size }}"

--- a/roles/tackle/templates/kai/kai-db-service.yaml.j2
+++ b/roles/tackle/templates/kai/kai-db-service.yaml.j2
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kai-db
+  namespace: "{{ app_namespace }}"
+spec:
+  selector:
+    app: kai-db
+  ports:
+    - protocol: TCP
+      port: 5432
+      targetPort: 5432

--- a/roles/tackle/templates/kai/kai-importer-deployment.yaml.j2
+++ b/roles/tackle/templates/kai/kai-importer-deployment.yaml.j2
@@ -18,26 +18,26 @@ spec:
         - name: kai-hub-importer
           image: "{{ kai_fqin }}"
           env:
-            - name: POSTGRES_HOST
+            - name: POSTGRESQL_HOST
               valueFrom:
                 secretKeyRef:
                   name: "{{ kai_database_secret_name }}"
-                  key: POSTGRES_HOST
-            - name: POSTGRES_DB
+                  key: POSTGRESQL_HOST
+            - name: POSTGRESQL_DATABASE
               valueFrom:
                 secretKeyRef:
                   name: "{{ kai_database_secret_name }}"
-                  key: POSTGRES_DB
-            - name: POSTGRES_PASSWORD
+                  key: POSTGRESQL_DB
+            - name: POSTGRESQL_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: "{{ kai_database_secret_name }}"
-                  key: POSTGRES_PASSWORD
-            - name: POSTGRES_USER
+                  key: POSTGRESQL_PASSWORD
+            - name: POSTGRESQL_USER
               valueFrom:
                 secretKeyRef:
                   name: "{{ kai_database_secret_name }}"
-                  key: POSTGRES_USER
+                  key: POSTGRESQL_USER
             - name: DEMO_MODE
               value: "{{ kai_enable_demo_mode }}"
             - name: HUB_URL

--- a/roles/tackle/templates/kai/kai-importer-deployment.yaml.j2
+++ b/roles/tackle/templates/kai/kai-importer-deployment.yaml.j2
@@ -1,0 +1,88 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kai-hub-importer
+  namespace: "{{ app_namespace }}"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kai-hub-importer
+  template:
+    metadata:
+      labels:
+        app: kai-hub-importer
+    spec:
+      containers:
+        - name: kai-hub-importer
+          image: "{{ kai_fqin }}"
+          env:
+            - name: POSTGRES_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ kai_database_secret_name }}"
+                  key: POSTGRES_HOST
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ kai_database_secret_name }}"
+                  key: POSTGRES_DB
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ kai_database_secret_name }}"
+                  key: POSTGRES_PASSWORD
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ kai_database_secret_name }}"
+                  key: POSTGRES_USER
+            - name: DEMO_MODE
+              value: "{{ kai_enable_demo_mode }}"
+            - name: HUB_URL
+              value: "{{ hub_url }}"
+            - name: IMPORTER_ARGS
+              value: "{{ kai_hub_importer_args }}"
+            - name: LOGLEVEL
+              value: "{{ kai_log_level }}"
+            - name: NUM_WORKERS
+              value: "8"
+            - name: USE_HUB_IMPORTER
+              value: "True"
+            - name: MODE
+              value: "importer"
+            - name: JWT
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ kai_jwt_secret_name }}"
+                  key: jwt
+{% if kai_api_key_secret_status.resources.0.data[kai_bam_secret_key]|default(false) %}
+            - name: GENAI_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ kai_api_key_secret_name }}"
+                  key: "{{ kai_bam_secret_key }}"
+{% endif %}
+{% if kai_api_key_secret_status.resources.0.data[kai_openai_secret_base_key]|default(false) %}
+            - name: OPENAI_API_BASE
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ kai_api_key_secret_name }}"
+                  key: "{{ kai_openai_secret_base_key }}"
+{% endif %}
+{% if kai_api_key_secret_status.resources.0.data[kai_openai_secret_api_key]|default(false) %}
+            - name: OPENAI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ kai_api_key_secret_name }}"
+                  key: "{{ kai_openai_secret_api_key }}"
+{% endif %}
+          volumeMounts:
+            - name: config-volume
+              mountPath: /podman_compose/kai-config.toml
+              subPath: kai-config.toml
+      volumes:
+        - name: config-volume
+          configMap:
+            name: "kai-config"

--- a/roles/tackle/templates/kai/kai-importer-service.yaml.j2
+++ b/roles/tackle/templates/kai/kai-importer-service.yaml.j2
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kai-hub-importer
+  namespace: "{{ app_namespace }}"
+spec:
+  selector:
+    app: kai-hub-importer
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080


### PR DESCRIPTION
Adds experimental support for deploying kai alongside konveyor in hub-importer mode. Prerequisite to run is creating a secret with the LLM credentials in it.

`kubectl create secret -n konveyor generic kai-api-key-secret --fromliteral=genai_key=[BAM_KEY] --from-literal=api_base=[OPENAI_BASE] --from-literal=api_key=[OPENAI_KEY]`