### PR TITLE
:sparkles: Add a log msg to clarify a secret is required to deploy kai

### DIFF
--- a/roles/tackle/tasks/kai.yml
+++ b/roles/tackle/tasks/kai.yml
@@ -8,6 +8,16 @@
     namespace: "{{ app_namespace }}"
   register: kai_api_key_secret_status
 
+- name: Verify kai-api-key-secret has been created
+  when: (kai_api_key_secret_status.resources|length) == 0
+  debug:
+    msg: >
+         Kai will not deploy until the credential secret exists.
+         kubectl create secret -n {{ app_namespace }} generic {{ kai_api_key_secret_name }}
+         --fromliteral=genai_key=[BAM_KEY]
+         --from-literal=api_base=[OPENAI_BASE]
+         --from-literal=api_key=[OPENAI_KEY]
+
 - when: (kai_api_key_secret_status.resources|length) > 0
   block:
     - name: Check if JWT token secret is defined


### PR DESCRIPTION
If the key does not exist it will print a message:

```
TASK [Verify kai-api-key-secret has been created] *******************************************************************************************************************************************************************************************
ok: [localhost] => {
    "msg": "Kai will not deploy until the credential secret exists. kubectl create secret -n konveyor generic kai-api-key-secret --fromliteral=genai_key=[BAM_KEY] --from-literal=api_base=[OPENAI_BASE] --from-literal=api_key=[OPENAI_KEY]\n"
}

PLAY RECAP **********************************************************************************************************************************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0  
```