### PR TITLE
:seedling: Customize Java provider image in install script

### DIFF
--- a/hack/install-tackle.sh
+++ b/hack/install-tackle.sh
@@ -24,6 +24,7 @@ HUB_IMAGE="${HUB_IMAGE:-quay.io/konveyor/tackle2-hub:latest}"
 UI_IMAGE="${UI_IMAGE:-quay.io/konveyor/tackle2-ui:latest}"
 UI_INGRESS_CLASS_NAME="${UI_INGRESS_CLASS_NAME:-nginx}"
 ADDON_ANALYZER_IMAGE="${ADDON_ANALYZER_IMAGE:-quay.io/konveyor/tackle2-addon-analyzer:latest}"
+JAVA_PROVIDER_IMAGE="${JAVA_PROVIDER_IMAGE:-quay.io/konveyor/java-external-provider:latest}"
 IMAGE_PULL_POLICY="${IMAGE_PULL_POLICY:-Always}"
 ANALYZER_CONTAINER_REQUESTS_MEMORY="${ANALYZER_CONTAINER_REQUESTS_MEMORY:-0}"
 ANALYZER_CONTAINER_REQUESTS_CPU="${ANALYZER_CONTAINER_REQUESTS_CPU:-0}"
@@ -121,6 +122,7 @@ spec:
   ui_image_fqin: ${UI_IMAGE}
   ui_ingress_class_name: ${UI_INGRESS_CLASS_NAME}
   analyzer_fqin: ${ADDON_ANALYZER_IMAGE}
+  provider_java_image_fqin: ${JAVA_PROVIDER_IMAGE}
   image_pull_policy: ${IMAGE_PULL_POLICY}
   analyzer_container_requests_memory: ${ANALYZER_CONTAINER_REQUESTS_MEMORY}
   analyzer_container_requests_cpu: ${ANALYZER_CONTAINER_REQUESTS_CPU}


### PR DESCRIPTION
Updating an install script from hack directory to accept env variable to allow specify java external provider image. Helpful for the provider debugging.