### PR TITLE
:bug: set mavenCacheDir.

### DIFF
--- a/roles/tackle/templates/customresource-addon-analyzer.yml.j2
+++ b/roles/tackle/templates/customresource-addon-analyzer.yml.j2
@@ -69,6 +69,7 @@ spec:
           depOpenSourceLabelsFile: /usr/local/etc/maven.default.index
           lspServerPath: /jdtls/bin/jdtls
           mavenSettingsFile: $(maven.settings.path)
+          mavenCacheDir: {{ cache_mount_path }}/m2
 ---
 kind: Extension
 apiVersion: tackle.konveyor.io/v1alpha1

--- a/roles/tackle/templates/customresource-addon-tech-discovery.yml.j2
+++ b/roles/tackle/templates/customresource-addon-tech-discovery.yml.j2
@@ -69,6 +69,7 @@ spec:
           depOpenSourceLabelsFile: /usr/local/etc/maven.default.index
           lspServerPath: /jdtls/bin/jdtls
           mavenSettingsFile: $(maven.settings.path)
+          mavenCacheDir: {{ cache_mount_path }}/m2
 ---
 kind: Extension
 apiVersion: tackle.konveyor.io/v1alpha1


### PR DESCRIPTION
Pass the mavenCacheDir property to the java provider which is used to build the maven global settings needed by JDTLS.