### PR TITLE
:sparkles: adding just auth to the install of tackle

### DIFF
--- a/.github/actions/install-tackle/action.yml
+++ b/.github/actions/install-tackle/action.yml
@@ -64,7 +64,7 @@ runs:
       export IMAGE_PULL_POLICY="${{ inputs.image-pull-policy }}"
       export ANALYZER_CONTAINER_REQUESTS_MEMORY="${{ inputs.analyzer-container-memory }}"
       export ANALYZER_CONTAINER_REQUESTS_CPU="${{ inputs.analyzer-container-cpu }}"
-      if [[ "true" == "${{ inputs.enable_auth }}"]]; then
+      if [[ "true" == "${{ inputs.enable_auth }}" ]]; then
         export FEATURE_AUTH_REQUIRED=true
       fi
       make install-tackle

--- a/.github/actions/install-tackle/action.yml
+++ b/.github/actions/install-tackle/action.yml
@@ -64,7 +64,7 @@ runs:
       export IMAGE_PULL_POLICY="${{ inputs.image-pull-policy }}"
       export ANALYZER_CONTAINER_REQUESTS_MEMORY="${{ inputs.analyzer-container-memory }}"
       export ANALYZER_CONTAINER_REQUESTS_CPU="${{ inputs.analyzer-container-cpu }}"
-      if [[ "true" == "${{ inputs.enable-auth }}"]]; then
+      if [[ "true" == "${{ inputs.enable_auth }}"]]; then
         export FEATURE_AUTH_REQUIRED=true
       fi
       make install-tackle

--- a/.github/actions/install-tackle/action.yml
+++ b/.github/actions/install-tackle/action.yml
@@ -30,6 +30,10 @@ inputs:
     description: "The memory request value for the analyzer task containers"
     required: false
     default: 0
+  enable_auth:
+    description: "Enable tackle with auth"
+    required: false
+    default: "false"
 runs:
   using: "composite"
   steps:
@@ -60,6 +64,9 @@ runs:
       export IMAGE_PULL_POLICY="${{ inputs.image-pull-policy }}"
       export ANALYZER_CONTAINER_REQUESTS_MEMORY="${{ inputs.analyzer-container-memory }}"
       export ANALYZER_CONTAINER_REQUESTS_CPU="${{ inputs.analyzer-container-cpu }}"
+      if [[ "true" == "${{ inputs.enable-auth }}"]]; then
+        export FEATURE_AUTH_REQUIRED=true
+      fi
       make install-tackle
     working-directory: ${{ github.action_path }}/../../..
     shell: bash


### PR DESCRIPTION
Follow on to only add the auth to the install of tackle to actually test login in UI tests.