### PR TITLE
:bug: disable keycloak servicemonitor

### DIFF
--- a/bundle/manifests/konveyor-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/konveyor-operator.clusterserviceversion.yaml
@@ -103,7 +103,7 @@ metadata:
     categories: Modernization & Migration
     certified: "false"
     containerImage: quay.io/konveyor/tackle2-operator:latest
-    createdAt: "2024-11-07T18:19:51Z"
+    createdAt: "2025-03-19T16:55:04Z"
     description: Konveyor is an open-source application modernization platform that
       helps organizations safely and predictably modernize applications to Kubernetes
       at scale.
@@ -235,6 +235,15 @@ spec:
           - create
           - update
           - patch
+          - delete
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - list
+          - watch
           - delete
         serviceAccountName: tackle-operator
       deployments:

--- a/helm/templates/rbac/cluster_role.yaml
+++ b/helm/templates/rbac/cluster_role.yaml
@@ -33,4 +33,13 @@ rules:
   - update
   - patch
   - delete
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
 #+kubebuilder:scaffold:rules

--- a/roles/tackle/tasks/main.yml
+++ b/roles/tackle/tasks/main.yml
@@ -429,6 +429,14 @@
         state: present
         definition: "{{ lookup('template', 'customresource-rhsso-keycloak.yml.j2') }}"
 
+    - name: "Remove Keycloak ServiceMonitor"
+      k8s:
+        api_version: monitoring.coreos.com/v1
+        kind: ServiceMonitor
+        state: absent
+        name: keycloak-service-monitor
+        namespace: "{{ app_namespace }}"
+
     - name: "Check RHSSO for readiness"
       k8s_info:
         api_version: "{{ rhsso_api_version }}"

--- a/roles/tackle/templates/customresource-rhsso-keycloak.yml.j2
+++ b/roles/tackle/templates/customresource-rhsso-keycloak.yml.j2
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: {{ rhsso_service_name }}
 spec:
+  DisableDefaultServiceMonitor: true
   instances: {{ rhsso_instances | default('1') }}
   externalDatabase:
     enabled: true


### PR DESCRIPTION
The reason for this is that there is a bug that causes the metrics/monitoring target to be broken and return a 404. Disabling it and cleaning up the servicemonitor is the best we can do to stop the noise right now. With RHBK there is no servicemonitor installed so nothing to do there.
https://issues.redhat.com/browse/RHSSO-1960