### PR TITLE
:bug: Add RHSSO servicemonitor networkpolicy

### DIFF
--- a/roles/tackle/templates/networkpolicy.yml.j2
+++ b/roles/tackle/templates/networkpolicy.yml.j2
@@ -60,3 +60,23 @@ spec:
           network.openshift.io/policy-group: monitoring
   - ports:
     - port: {{ hub_metrics_port }}
+{% if app_profile == 'mta' %}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ app_name }}-rhsso-metrics
+  namespace: {{ app_namespace }}
+spec:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          network.openshift.io/policy-group: monitoring
+  - ports:
+    - port: 8383
+    - port: 8686
+  podSelector:
+    matchLabels:
+      name: rhsso-operator
+{% endif %}


### PR DESCRIPTION
The servicemonitor endpoints are defined but inaccessible if monitoring is enabled on the namespace because we do not have a networkpolicy that allows access. RHBK has no servicemonitors, so in the case of RHBK there is nothing to do.