### PR TITLE
:bug: Increase java provider memory.

### DIFF
--- a/roles/tackle/defaults/main.yml
+++ b/roles/tackle/defaults/main.yml
@@ -185,9 +185,9 @@ provider_nodejs_service_name: "{{ app_name }}-{{ provider_nodejs_name }}-{{ prov
 
 provider_java_component_name: "extension"
 provider_java_container_limits_cpu: "1"
-provider_java_container_limits_memory: "2Gi"
+provider_java_container_limits_memory: "2.5Gi"
 provider_java_container_requests_cpu: "1"
-provider_java_container_requests_memory: "2Gi"
+provider_java_container_requests_memory: "2.5Gi"
 provider_java_image_fqin: "{{ lookup('env', 'RELATED_IMAGE_PROVIDER_JAVA') }}"
 provider_java_name: "java"
 provider_java_service_name: "{{ app_name }}-{{ provider_java_name }}-{{ provider_java_component_name }}"


### PR DESCRIPTION
Newer version of jdtls and additional rules seem to require more memory.
Fixes:
```
time="2025-03-19T17:24:11Z" level=error msg="language server stopped with error" client=6178324807082304109 error="exec: not started" provider=java
```
2.5Gi resolves the problem on my minikube for source+deps and multiple common targets.