### PR TITLE
:ghost: Tech discovery should run at priority=1.

### DIFF
--- a/roles/tackle/templates/customresource-addon-tech-discovery.yml.j2
+++ b/roles/tackle/templates/customresource-addon-tech-discovery.yml.j2
@@ -30,6 +30,7 @@ metadata:
   labels:
     konveyor.io/discovery: "technology"
 spec:
+  priority: 1
   dependencies: [ {{ language_discovery_name }} ]
   data:
     mode:


### PR DESCRIPTION
Related to: https://github.com/konveyor/tackle2-hub/pull/830