### PR TITLE
:sparkles: Support disabling maven search.

### DIFF
--- a/bundle/manifests/konveyor-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/konveyor-operator.clusterserviceversion.yaml
@@ -148,7 +148,7 @@ metadata:
     categories: Modernization & Migration
     certified: "false"
     containerImage: quay.io/konveyor/tackle2-operator:latest
-    createdAt: "2025-08-01T12:20:51Z"
+    createdAt: "2025-08-04T19:33:15Z"
     description: Konveyor is an open-source application modernization platform that
       helps organizations safely and predictably modernize applications to Kubernetes
       at scale.

--- a/roles/tackle/defaults/main.yml
+++ b/roles/tackle/defaults/main.yml
@@ -14,6 +14,9 @@ feature_isolate_namespace: true
 feature_analysis_archiver: true
 feature_discovery: true
 
+# Options.
+disable_maven_search: false
+
 # Environment
 openshift_cluster: false
 image_pull_policy: "Always"

--- a/roles/tackle/templates/customresource-extension.yml.j2
+++ b/roles/tackle/templates/customresource-extension.yml.j2
@@ -49,6 +49,7 @@ spec:
           bundles: /jdtls/java-analyzer-bundle/java-analyzer-bundle.core/target/java-analyzer-bundle.core-1.0.0-SNAPSHOT.jar
           depOpenSourceLabelsFile: /usr/local/etc/maven.default.index
           lspServerPath: /jdtls/bin/jdtls
+          disableMavenSearch: {{ disable_maven_search }}
           mavenInsecure: $(maven.insecure)
           mavenSettingsFile: $(maven.settings.path)
           mavenCacheDir: {{ cache_mount_path }}/m2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configuration option to enable or disable Maven search for the Java provider.
* **Chores**
  * Updated metadata timestamp in the operator manifest.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->