### PR TITLE
:seedling: Add kantra image to bundle

### DIFF
--- a/.github/actions/make-bundle/action.yml
+++ b/.github/actions/make-bundle/action.yml
@@ -49,6 +49,10 @@ inputs:
     description: "image uri for generic provider (ie. quay.io/<namespace>/<image-name>:<tag>)"
     required: false
     default: ""
+  kantra:
+    description: "image uri for kantra (ie. quay.io/<namespace>/<image-name>:<tag>)"
+    required: false
+    default: ""
   version:
     description: "operator version"
     required: false
@@ -85,6 +89,7 @@ runs:
       [ -n "${{ inputs.addon_discovery }}" ] && OPTS+=" --set images.addon_discovery=${{ inputs.addon_discovery }}"
       [ -n "${{ inputs.provider_generic }}" ] && OPTS+=" --set images.provider_generic=${{ inputs.provider_generic }}"
       [ -n "${{ inputs.provider_java }}" ] && OPTS+=" --set images.provider_java=${{ inputs.provider_java }}"
+      [ -n "${{ inputs.kantra }}" ] && OPTS+=" --set images.kantra=${{ inputs.kantra }}"
       HELM_OPTS="${OPTS}" make bundle
       cat ./bundle/manifests/konveyor-operator.clusterserviceversion.yaml
       make bundle-build

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -293,7 +293,6 @@ jobs:
       operator_bundle: quay.io/konveyor/tackle2-operator-bundle:${{ inputs.version }}
       api_tests_ref: ${{ inputs.branch }}
       ui_tests_ref: ${{ inputs.branch }}
-      cli_tests_ref: ${{ inputs.branch }}
 
   publish-bundle:
     name: Publish Bundle Manifest

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -160,6 +160,8 @@ jobs:
             image: konveyor/kantra
           - repo: konveyor/tackle2-addon-discovery
             image: konveyor/tackle2-addon-discovery
+          - repo: konveyor/kantra
+            image: konveyor/kantra
           - repo: konveyor/kai
             image: konveyor/kai-solution-server
       fail-fast: true
@@ -236,6 +238,7 @@ jobs:
         addon_discovery: quay.io/konveyor/tackle2-addon-discovery:${{ inputs.version }}
         provider_generic: quay.io/konveyor/generic-external-provider:${{ inputs.version }}
         provider_java: quay.io/konveyor/java-external-provider:${{ inputs.version }}
+        kantra: quay.io/konveyor/kantra:${{ inputs.version }}
         kai: quay.io/konveyor/kai-solution-server:${{ inputs.version }}
         # The ones we don't own
         oauth_proxy: quay.io/konveyor/origin-oauth-proxy:${{ inputs.version }}
@@ -290,6 +293,7 @@ jobs:
       operator_bundle: quay.io/konveyor/tackle2-operator-bundle:${{ inputs.version }}
       api_tests_ref: ${{ inputs.branch }}
       ui_tests_ref: ${{ inputs.branch }}
+      cli_tests_ref: ${{ inputs.branch }}
 
   publish-bundle:
     name: Publish Bundle Manifest
@@ -353,6 +357,7 @@ jobs:
           "konveyor/tackle2-addon-discovery"
           "konveyor/tackle2-addon"
           "konveyor/operator"
+          "konveyor/kantra"
           "konveyor/kai"
         )
 

--- a/bundle/manifests/konveyor-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/konveyor-operator.clusterserviceversion.yaml
@@ -353,6 +353,8 @@ spec:
                   value: quay.io/konveyor/generic-external-provider:latest
                 - name: RELATED_IMAGE_PROVIDER_JAVA
                   value: quay.io/konveyor/java-external-provider:latest
+                - name: RELATED_IMAGE_KANTRA
+                  value: quay.io/konveyor/kantra:latest
                 - name: RELATED_IMAGE_KAI
                   value: quay.io/konveyor/kai-solution-server:latest
                 image: quay.io/konveyor/tackle2-operator:latest
@@ -552,6 +554,8 @@ spec:
     name: provider-generic
   - image: quay.io/konveyor/java-external-provider:latest
     name: provider-java
+  - image: quay.io/konveyor/kantra:latest
+    name: kantra
   - image: quay.io/konveyor/kai-solution-server:latest
     name: kai
   version: 99.0.0

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -57,6 +57,8 @@ spec:
           value: {{ .Values.images.provider_generic }}
         - name: RELATED_IMAGE_PROVIDER_JAVA
           value: {{ .Values.images.provider_java }}
+        - name: RELATED_IMAGE_KANTRA
+          value: {{ .Values.images.kantra }}
         - name: RELATED_IMAGE_KAI
           value: {{ .Values.images.kai }}
         name: tackle-operator

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -23,4 +23,5 @@ images:
   addon_discovery: quay.io/konveyor/tackle2-addon-discovery:latest
   provider_generic: quay.io/konveyor/generic-external-provider:latest
   provider_java: quay.io/konveyor/java-external-provider:latest
+  kantra: quay.io/konveyor/kantra:latest
   kai: quay.io/konveyor/kai-solution-server:latest

--- a/roles/tackle/defaults/main.yml
+++ b/roles/tackle/defaults/main.yml
@@ -200,6 +200,9 @@ provider_java_image_fqin: "{{ lookup('env', 'RELATED_IMAGE_PROVIDER_JAVA') }}"
 provider_java_name: "java"
 provider_java_service_name: "{{ app_name }}-{{ provider_java_name }}-{{ provider_java_component_name }}"
 
+kantra_fqin: "{{ lookup('env', 'RELATED_IMAGE_KANTRA') }}"
+kantra_name: "kantra"
+
 language_discovery_fqin: "{{ lookup('env', 'RELATED_IMAGE_ADDON_DISCOVERY') }}"
 language_discovery_name: "language-discovery"
 language_discovery_component_name: "addon"


### PR DESCRIPTION
Adding kantra image to bundle to allow its CI test with bundle and as
part of upstream release process. There is no plan to run anything with
kantra image in k8s-based Konveyor installation.

Related to https://github.com/konveyor/operator/issues/460

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated the "kantra" component and image throughout the release, build, and deployment workflows.
  * Added "kantra" as a related image in operator manifests and Helm configuration.
  * Introduced new configuration options for specifying the "kantra" image in deployment and workflow settings.

* **Chores**
  * Updated workflow and configuration files to support the inclusion and management of the "kantra" component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->