### PR TITLE
:sparkles: Disable ingress for keycloak CR

### DIFF
--- a/roles/tackle/templates/customresource-rhbk-keycloak.yml.j2
+++ b/roles/tackle/templates/customresource-rhbk-keycloak.yml.j2
@@ -5,6 +5,8 @@ metadata:
   namespace: {{ app_namespace }}
 spec:
   instances: 1
+  ingress:
+    enabled: false
   db:
     vendor: postgres
     database: {{ keycloak_database_db_name }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added ingress configuration to the Keycloak custom resource.
  * Ingress is now disabled by default, improving control over external exposure.
  * Users can enable ingress via the new spec.ingress.enabled field when needed.
  * All other settings (instances, database, etc.) remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->