### PR TITLE
:sparkles: Set run_api_tests to false in create-release.yml

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -282,6 +282,7 @@ jobs:
       kantra: quay.io/konveyor/kantra:${{ inputs.version }}
       api_tests_ref: ${{ inputs.branch }}
       ui_tests_ref: ${{ inputs.branch }}
+      run_api_tests: false
       run_koncur_hub_tests: true
       run_koncur_kantra_tests: true
       run_windows_kantra_tests: false


### PR DESCRIPTION
Disable API tests in the release workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release validation workflow to skip API tests while preserving all other test configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->