### PR TITLE
:seedling: Update UI deployment to use HTTP GET liveness probe

### DIFF
--- a/roles/tackle/templates/deployment-ui.yml.j2
+++ b/roles/tackle/templates/deployment-ui.yml.j2
@@ -84,9 +84,9 @@ spec:
               path: /
               port: {{ ui_port }}
               scheme: {{ ui_proto|upper }}
-            initialDelaySeconds: 10
-            timeoutSeconds: 1
-            periodSeconds: 5
+            initialDelaySeconds: 30
+            timeoutSeconds: 5
+            periodSeconds: 10
             successThreshold: 1
             failureThreshold: 3
           readinessProbe:
@@ -94,8 +94,8 @@ spec:
               path: /
               port: {{ ui_port }}
               scheme: {{ ui_proto|upper }}
-            initialDelaySeconds: 10
-            timeoutSeconds: 1
+            initialDelaySeconds: 5
+            timeoutSeconds: 3
             periodSeconds: 5
             successThreshold: 1
             failureThreshold: 3

--- a/roles/tackle/templates/deployment-ui.yml.j2
+++ b/roles/tackle/templates/deployment-ui.yml.j2
@@ -80,11 +80,10 @@ spec:
               cpu: {{ ui_container_requests_cpu }}
               memory: {{ ui_container_requests_memory }}
           livenessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - '-c'
-                - 'ps -A | grep node'
+            httpGet:
+              path: /
+              port: {{ ui_port }}
+              scheme: {{ ui_proto|upper }}
             initialDelaySeconds: 10
             timeoutSeconds: 1
             periodSeconds: 5


### PR DESCRIPTION
This change updates the UI deployment to use an HTTP GET liveness probe instead of an exec probe. The exec probe could cause issues with the UI deployment if the UI deployment changes and no longer runs on node/express. The HTTP GET probe is a more reliable way to determine if the UI is running correctly.

Resolves: #592

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UI deployment health checks by validating that the application responds successfully over HTTP.
  * Supports the configured UI protocol when performing liveness checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->