### PR TITLE
:sparkles: Add agentic controller as an opt-in operand

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ endif
 # putting it last allows the operator image to be overridden
 .PHONY: bundle
 bundle: helm operator-sdk ## Generate bundle manifests and metadata, then validate generated files.
-	$(HELM) template --set images.operator=${IMG} --set version=$(VERSION) --set olm=true $(HELM_OPTS) ./helm | $(OPERATOR_SDK) generate bundle --extra-service-accounts tackle-hub,tackle-ui $(BUNDLE_GEN_FLAGS)
+	$(HELM) template --set images.operator=${IMG} --set version=$(VERSION) --set olm=true $(HELM_OPTS) ./helm | $(OPERATOR_SDK) generate bundle --extra-service-accounts tackle-hub,tackle-ui,agentic-controller $(BUNDLE_GEN_FLAGS)
 	$(OPERATOR_SDK) bundle validate ./bundle
 
 .PHONY: bundle-sync-check

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The Konveyor Operator fully manages the deployment and life cycle of Konveyor on
 
 Please ensure the following requirements are met prior installation.
 
-* [__k8s v1.22+__](https://kubernetes.io/) or [__OpenShift 4.9+__](https://www.openshift.com/)
+* [__k8s v1.25+__](https://kubernetes.io/) or [__OpenShift 4.12+__](https://www.openshift.com/)
 * [__Persistent Storage__](https://kubernetes.io/docs/concepts/storage/persistent-volumes/)
 * [__Operator Lifecycle Manager (OLM) support__](https://olm.operatorframework.io/)
 * [__Ingress support__](https://kubernetes.io/docs/concepts/services-networking/ingress/)

--- a/bundle/manifests/konveyor-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/konveyor-operator.clusterserviceversion.yaml
@@ -148,7 +148,7 @@ metadata:
     categories: Modernization & Migration
     certified: "false"
     containerImage: quay.io/konveyor/tackle2-operator:latest
-    createdAt: "2026-06-03T16:15:05Z"
+    createdAt: "2026-08-27T17:14:51Z"
     description: Konveyor is an open-source application modernization platform that
       helps organizations safely and predictably modernize applications to Kubernetes
       at scale.
@@ -191,6 +191,43 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
+    - description: AgentRun is a request to execute a single Agent with specific selections.
+      displayName: Agent Run
+      kind: AgentRun
+      name: agentruns.konveyor.io
+      version: v1alpha1
+    - description: Agent is a capability definition declaring what is available for
+        execution.
+      displayName: Agent
+      kind: Agent
+      name: agents.konveyor.io
+      version: v1alpha1
+    - description: AgentWorkflowRun is a request to execute an AgentWorkflow.
+      displayName: Agent Workflow Run
+      kind: AgentWorkflowRun
+      name: agentworkflowruns.konveyor.io
+      version: v1alpha1
+    - description: AgentWorkflow is a reusable workflow combining a high-level guide
+        with an ordered sequence of stages.
+      displayName: Agent Workflow
+      kind: AgentWorkflow
+      name: agentworkflows.konveyor.io
+      version: v1alpha1
+    - description: Gateway is an LLM service endpoint serving exactly one provider/model.
+      displayName: Gateway
+      kind: Gateway
+      name: gateways.konveyor.io
+      version: v1alpha1
+    - description: SkillCard is an individual agent capability or behavioral constraint.
+      displayName: Skill Card
+      kind: SkillCard
+      name: skillcards.konveyor.io
+      version: v1alpha1
+    - description: SkillCollection is a group of skills.
+      displayName: Skill Collection
+      kind: SkillCollection
+      name: skillcollections.konveyor.io
+      version: v1alpha1
     - description: Tackle Addon
       displayName: Addon
       kind: Addon
@@ -273,6 +310,131 @@ spec:
       clusterPermissions:
       - rules:
         - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - create
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - agents.x-k8s.io
+          resources:
+          - sandboxes
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - konveyor.io
+          resources:
+          - agentruns
+          - agents
+          - agentworkflowruns
+          - agentworkflows
+          - gateways
+          - skillcards
+          - skillcollections
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - konveyor.io
+          resources:
+          - agentruns/finalizers
+          - agents/finalizers
+          - agentworkflowruns/finalizers
+          - agentworkflows/finalizers
+          - gateways/finalizers
+          - skillcards/finalizers
+          - skillcollections/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - konveyor.io
+          resources:
+          - agentruns/status
+          - agents/status
+          - agentworkflowruns/status
+          - agentworkflows/status
+          - gateways/status
+          - skillcards/status
+          - skillcollections/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - rolebindings
+          - roles
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        serviceAccountName: agentic-controller
+      - rules:
+        - apiGroups:
           - operator.openshift.io
           resources:
           - dnses
@@ -312,6 +474,14 @@ spec:
           - list
           - watch
           - delete
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
         serviceAccountName: tackle-operator
       deployments:
       - name: tackle-operator
@@ -380,6 +550,20 @@ spec:
                   value: quay.io/konveyor/kai-solution-server:latest
                 - name: RELATED_IMAGE_LIGHTSPEED_STACK
                   value: quay.io/lightspeed-core/lightspeed-stack:latest
+                - name: RELATED_IMAGE_AGENTIC_CONTROLLER
+                  value: quay.io/konveyor/agentic-controller:latest
+                - name: RELATED_IMAGE_AGENT_BASE
+                  value: quay.io/konveyor/agent-base:latest
+                - name: RELATED_IMAGE_AGENT_GO
+                  value: quay.io/konveyor/agent-go:latest
+                - name: RELATED_IMAGE_AGENT_JAVA
+                  value: quay.io/konveyor/agent-java:latest
+                - name: RELATED_IMAGE_AGENT_CSHARP
+                  value: quay.io/konveyor/agent-csharp:latest
+                - name: RELATED_IMAGE_AGENT_NODEJS
+                  value: quay.io/konveyor/agent-nodejs:latest
+                - name: RELATED_IMAGE_AGENT_SKILLS
+                  value: quay.io/konveyor/skills:latest
                 image: quay.io/konveyor/tackle2-operator:latest
                 imagePullPolicy: Always
                 livenessProbe:
@@ -408,6 +592,39 @@ spec:
                 runAsNonRoot: true
               serviceAccountName: tackle-operator
       permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: agentic-controller
       - rules:
         - apiGroups:
           - ""
@@ -590,4 +807,18 @@ spec:
     name: kai
   - image: quay.io/lightspeed-core/lightspeed-stack:latest
     name: lightspeed-stack
+  - image: quay.io/konveyor/agentic-controller:latest
+    name: agentic-controller
+  - image: quay.io/konveyor/agent-base:latest
+    name: agent-base
+  - image: quay.io/konveyor/agent-go:latest
+    name: agent-go
+  - image: quay.io/konveyor/agent-java:latest
+    name: agent-java
+  - image: quay.io/konveyor/agent-csharp:latest
+    name: agent-csharp
+  - image: quay.io/konveyor/agent-nodejs:latest
+    name: agent-nodejs
+  - image: quay.io/konveyor/skills:latest
+    name: agent-skills
   version: 99.0.0

--- a/bundle/manifests/konveyor-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/konveyor-operator.clusterserviceversion.yaml
@@ -148,7 +148,7 @@ metadata:
     categories: Modernization & Migration
     certified: "false"
     containerImage: quay.io/konveyor/tackle2-operator:latest
-    createdAt: "2026-08-27T17:14:51Z"
+    createdAt: "2026-08-27T20:07:33Z"
     description: Konveyor is an open-source application modernization platform that
       helps organizations safely and predictably modernize applications to Kubernetes
       at scale.
@@ -770,7 +770,7 @@ spec:
   - email: konveyor-dev@googlegroups.com
     name: Konveyor Community
   maturity: alpha
-  minKubeVersion: 1.22.0
+  minKubeVersion: 1.25.0
   provider:
     name: Konveyor
     url: https://www.konveyor.io

--- a/bundle/manifests/konveyor.io_agentruns.yaml
+++ b/bundle/manifests/konveyor.io_agentruns.yaml
@@ -1,0 +1,535 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.21.0
+  creationTimestamp: null
+  name: agentruns.konveyor.io
+spec:
+  group: konveyor.io
+  names:
+    kind: AgentRun
+    listKind: AgentRunList
+    plural: agentruns
+    shortNames:
+    - ar
+    singular: agentrun
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.agentRef
+      name: Agent
+      type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.duration
+      name: Duration
+      priority: 1
+      type: integer
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          AgentRun is a request to execute a single Agent with specific selections.
+          It references an Agent, selects a gateway, carries instructions and
+          key-value parameters (delivered via /run/konveyor/params.json and
+          referenced in prompt text as $(agent.<name>) / $(workflow.<name>) — ADR
+          0009). The controller validates, resolves skills to ImageVolumes, creates
+          a Sandbox, and tracks status to completion.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              AgentRunSpec defines the desired state of an AgentRun.
+              The spec is immutable once created — delete and recreate to change values.
+            properties:
+              agentRef:
+                description: AgentRef is the name of the Agent CR to execute.
+                minLength: 1
+                type: string
+              env:
+                description: |-
+                  Env is a list of additional environment variables to set in the
+                  Sandbox container. Passed through to the Sandbox unchanged.
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: |-
+                        Name of the environment variable.
+                        May consist of any printable ASCII characters except '='.
+                      type: string
+                    value:
+                      description: |-
+                        Variable references $(VAR_NAME) are expanded
+                        using the previously defined environment variables in the container and
+                        any service environment variables. If a variable cannot be resolved,
+                        the reference in the input string will be unchanged. Double $$ are reduced
+                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                        Escaped references will never be expanded, regardless of whether the variable
+                        exists or not.
+                        Defaults to "".
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fieldRef:
+                          description: |-
+                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fileKeyRef:
+                          description: |-
+                            FileKeyRef selects a key of the env file.
+                            Requires the EnvFiles feature gate to be enabled.
+                          properties:
+                            key:
+                              description: |-
+                                The key within the env file. An invalid key will prevent the pod from starting.
+                                The keys defined within a source may consist of any printable ASCII characters except '='.
+                                During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                              type: string
+                            optional:
+                              default: false
+                              description: |-
+                                Specify whether the file or its key must be defined. If the file or key
+                                does not exist, then the env var is not published.
+                                If optional is set to true and the specified key does not exist,
+                                the environment variable will not be set in the Pod's containers.
+
+                                If optional is set to false and the specified key does not exist,
+                                an error will be returned during Pod creation.
+                              type: boolean
+                            path:
+                              description: |-
+                                The path within the volume from which to select the file.
+                                Must be relative and may not contain the '..' path or start with '..'.
+                              type: string
+                            volumeName:
+                              description: The name of the volume mount containing
+                                the env file.
+                              type: string
+                          required:
+                          - key
+                          - path
+                          - volumeName
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        resourceFieldRef:
+                          description: |-
+                            Selects a resource of the container: only resources limits and requests
+                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              envFrom:
+                description: |-
+                  EnvFrom is a list of sources to populate environment variables in
+                  the Sandbox container. Passed through to the Sandbox unchanged.
+                items:
+                  description: EnvFromSource represents the source of a set of ConfigMaps
+                    or Secrets
+                  properties:
+                    configMapRef:
+                      description: The ConfigMap to select from
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the ConfigMap must be defined
+                          type: boolean
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    prefix:
+                      description: |-
+                        Optional text to prepend to the name of each environment variable.
+                        May consist of any printable ASCII characters except '='.
+                      type: string
+                    secretRef:
+                      description: The Secret to select from
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the Secret must be defined
+                          type: boolean
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  type: object
+                type: array
+              execution:
+                description: |-
+                  Execution carries the resolved supervision mode and budget limits
+                  for this run. For a standalone run these are set by the run
+                  creator (mode) and default from the Agent (limits). For a workflow
+                  stage the AgentWorkflowRun controller stamps the stage-resolved
+                  values here (ADR 0018). Unset fields resolve against the Agent's
+                  Execution defaults; mode resolves to auto when unset everywhere.
+                properties:
+                  maxCost:
+                    description: |-
+                      MaxCost is the maximum cumulative cost in USD before wind-down,
+                      as a decimal string (e.g. "10.00"). USD only: the enforcement
+                      threshold must match the currency of reported usage, which is USD
+                      across the supported runtimes. Reported cost may carry an ISO 4217
+                      currency; this threshold does not.
+                    pattern: ^[0-9]+(\.[0-9]{1,2})?$
+                    type: string
+                  maxTurns:
+                    description: |-
+                      MaxTurns is the maximum number of turns before wind-down. The unit
+                      is runtime-defined (e.g. Goose counts turns without user input).
+                    minimum: 1
+                    type: integer
+                  mode:
+                    description: Mode is the supervision policy for tool calls. Defaults
+                      to auto.
+                    enum:
+                    - auto
+                    - approve
+                    type: string
+                type: object
+              gateway:
+                description: |-
+                  Gateway selects the Gateway (provider/model combination) for this
+                  run. Must be one of the gateways declared on the referenced Agent.
+                minLength: 1
+                type: string
+              gitConfig:
+                description: |-
+                  GitConfig overrides the Agent's git commit identity for this run.
+                  When set it replaces the Agent's GitConfig wholesale (name and email
+                  together); when unset the run uses the Agent's identity, then the
+                  harness default.
+                properties:
+                  userEmail:
+                    description: |-
+                      UserEmail maps to git config user.email for the agent's commits.
+                      Must be a bare address (local@domain) with no angle brackets,
+                      whitespace, or control characters — go-git wraps it in <> unescaped.
+                    maxLength: 254
+                    pattern: ^[^\x00-\x20\x7f<>@]+@[^\x00-\x20\x7f<>@]+\.[^\x00-\x20\x7f<>@]+$
+                    type: string
+                  userName:
+                    description: |-
+                      UserName maps to git config user.name for the agent's commits.
+                      go-git does not escape the identity, so reject angle brackets and
+                      control characters that would corrupt or forge the commit ident.
+                    maxLength: 128
+                    pattern: ^[^\x00-\x1f\x7f<>]+$
+                    type: string
+                type: object
+                x-kubernetes-validations:
+                - message: userName and userEmail must both be set
+                  rule: has(self.userName) && has(self.userEmail)
+              instructions:
+                description: |-
+                  Instructions are task-specific instructions for this run.
+                  Composed with the Agent's prompt at execution time. Supports
+                  $(agent.<name>) / $(workflow.<name>) substitution.
+                type: string
+              params:
+                description: |-
+                  Params supplies values for the Agent's declared parameters.
+                  Resolved values are written to /run/konveyor/params.json in the
+                  Sandbox (see ADR 0009); they are not injected as env vars.
+                items:
+                  description: ParamValue supplies a value for a declared Agent parameter.
+                  properties:
+                    name:
+                      description: Name is the parameter name, matching an Agent param
+                        declaration.
+                      minLength: 1
+                      type: string
+                    value:
+                      description: Value is the parameter value.
+                      type: string
+                  required:
+                  - name
+                  - value
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              workflowParams:
+                description: |-
+                  WorkflowParams carries the resolved, type-coerced workflow-level
+                  parameters for a stage run, as a JSON object stamped by the
+                  AgentWorkflowRun controller (ADR 0018). The AgentRun controller
+                  writes it verbatim to the "workflow" section of params.json and
+                  uses its values for $(workflow.<name>) substitution. Empty for
+                  standalone runs. Coercion happens in the workflow controller,
+                  which owns the AgentWorkflow param declarations.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+            required:
+            - agentRef
+            type: object
+            x-kubernetes-validations:
+            - message: spec is immutable
+              rule: self == oldSelf
+          status:
+            description: AgentRunStatus defines the observed state of an AgentRun.
+            properties:
+              completionTime:
+                description: CompletionTime is the time the Sandbox finished.
+                format: date-time
+                type: string
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations of the
+                  AgentRun's state. Ready tracks the run's overall outcome (False
+                  while in progress with the current step as its reason, True on
+                  success); ACPReady tracks whether the agent's ACP endpoint accepts
+                  connections (see AgentRunConditionACPReady). Succeeded is the
+                  terminal outcome (see AgentRunConditionSucceeded): Unknown while
+                  running, True on clean completion, False with a reason
+                  (Failed, LimitReached) otherwise.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              duration:
+                description: Duration is the wall-clock duration of the run in seconds.
+                format: int64
+                type: integer
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              phase:
+                default: Pending
+                description: |-
+                  Phase is the current phase of the AgentRun. Running means the sandbox
+                  pod is running (the agent process is executing); it says nothing about
+                  whether the agent's ACP endpoint accepts connections yet — that is the
+                  ACPReady condition. A run whose pod finishes before the controller
+                  observes it running may go straight from Pending to a terminal phase.
+                enum:
+                - Pending
+                - Running
+                - Succeeded
+                - Failed
+                type: string
+              sandboxName:
+                description: SandboxName is the name of the Sandbox CR created for
+                  this run.
+                type: string
+              secretKeyRef:
+                description: |-
+                  SecretKeyRef references a Secret containing the ACP authentication key
+                  for connecting to the agent's ACP endpoint. The harness generates
+                  a random key per run and stores it in this Secret.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              startTime:
+                description: |-
+                  StartTime is the time the sandbox pod started running (the Sandbox
+                  creation time if the pod finished before the controller saw it run).
+                format: date-time
+                type: string
+              terminationData:
+                description: |-
+                  TerminationData is the raw JSON the harness wrote to the pod's
+                  termination message (/dev/termination-log) on exit — typically a
+                  usage/cost report. The controller copies it verbatim and never
+                  interprets it; platform-specific UIs read the harness's schema
+                  (ADR 0011/0018). Absent if the harness wrote nothing parseable.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/bundle/manifests/konveyor.io_agents.yaml
+++ b/bundle/manifests/konveyor.io_agents.yaml
@@ -1,0 +1,309 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.21.0
+  creationTimestamp: null
+  name: agents.konveyor.io
+spec:
+  group: konveyor.io
+  names:
+    kind: Agent
+    listKind: AgentList
+    plural: agents
+    shortNames:
+    - ag
+    singular: agent
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.image
+      name: Image
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          Agent is a capability definition declaring what is available for execution.
+          It references SkillCards, SkillCollections, Gateways, a container image,
+          a prompt, and typed parameters. An Agent does not select a specific model —
+          gateway selection happens at execution time via AgentRun.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AgentSpec defines the desired state of an Agent.
+            properties:
+              execution:
+                description: |-
+                  Execution declares the default budget limits (maxTurns, maxCost)
+                  for runs of this Agent. Runs and workflow stages may override
+                  these; the AgentRun carries the resolved values (ADR 0018). The
+                  Agent does not declare mode — mode is an execution-time concern set
+                  on the AgentRun or stage (ADR 0011/0018).
+                properties:
+                  maxCost:
+                    description: |-
+                      MaxCost is the maximum cumulative cost in USD before wind-down,
+                      as a decimal string (e.g. "10.00"). USD only: the enforcement
+                      threshold must match the currency of reported usage, which is USD
+                      across the supported runtimes. Reported cost may carry an ISO 4217
+                      currency; this threshold does not.
+                    pattern: ^[0-9]+(\.[0-9]{1,2})?$
+                    type: string
+                  maxTurns:
+                    description: |-
+                      MaxTurns is the maximum number of turns before wind-down. The unit
+                      is runtime-defined (e.g. Goose counts turns without user input).
+                    minimum: 1
+                    type: integer
+                type: object
+              gateways:
+                description: |-
+                  Gateways is the set of gateways (provider/model combinations)
+                  available for runs. At least one gateway must be specified.
+                items:
+                  description: AgentGatewayRef references a Gateway by name.
+                  properties:
+                    ref:
+                      description: Ref is the name of a Gateway CR in the same namespace.
+                      minLength: 1
+                      type: string
+                  required:
+                  - ref
+                  type: object
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - ref
+                x-kubernetes-list-type: map
+              gitConfig:
+                description: |-
+                  GitConfig sets the default git commit identity for the agent's
+                  commits. An AgentRun may override it per run. When unset, commits
+                  use the harness default identity.
+                properties:
+                  userEmail:
+                    description: |-
+                      UserEmail maps to git config user.email for the agent's commits.
+                      Must be a bare address (local@domain) with no angle brackets,
+                      whitespace, or control characters — go-git wraps it in <> unescaped.
+                    maxLength: 254
+                    pattern: ^[^\x00-\x20\x7f<>@]+@[^\x00-\x20\x7f<>@]+\.[^\x00-\x20\x7f<>@]+$
+                    type: string
+                  userName:
+                    description: |-
+                      UserName maps to git config user.name for the agent's commits.
+                      go-git does not escape the identity, so reject angle brackets and
+                      control characters that would corrupt or forge the commit ident.
+                    maxLength: 128
+                    pattern: ^[^\x00-\x1f\x7f<>]+$
+                    type: string
+                type: object
+                x-kubernetes-validations:
+                - message: userName and userEmail must both be set
+                  rule: has(self.userName) && has(self.userEmail)
+              image:
+                description: Image is the container image carrying the agent runtime
+                  and toolchains.
+                minLength: 1
+                type: string
+              params:
+                description: Params declares the typed parameters this Agent accepts.
+                items:
+                  description: |-
+                    Param declares a typed parameter that an Agent or AgentWorkflow
+                    accepts. A run (AgentRun / AgentWorkflowRun) supplies values via
+                    ParamValue. Resolved values are delivered to the Sandbox in
+                    /run/konveyor/params.json (see ADR 0009) and may be referenced in
+                    prompt text with $(agent.<name>) / $(workflow.<name>).
+                  properties:
+                    default:
+                      description: Default is the default value if not supplied by
+                        a run.
+                      type: string
+                    description:
+                      description: Description explains the purpose of the parameter.
+                      type: string
+                    name:
+                      description: |-
+                        Name is the parameter name. Referenced in prompt text as
+                        $(agent.<name>) or $(workflow.<name>) and delivered in
+                        params.json under the corresponding section.
+                      minLength: 1
+                      pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                      type: string
+                    required:
+                      description: |-
+                        Required indicates whether the parameter must be supplied.
+                        A parameter with a default is never required.
+                      type: boolean
+                    type:
+                      default: string
+                      description: |-
+                        Type is the parameter type. Controls JSON coercion in
+                        params.json: number as a JSON number, boolean as a JSON boolean,
+                        string as a JSON string.
+                      enum:
+                      - string
+                      - number
+                      - boolean
+                      type: string
+                  required:
+                  - name
+                  type: object
+                  x-kubernetes-validations:
+                  - message: a parameter with a default value cannot be required
+                    rule: '!(has(self.required) && self.required && has(self.default)
+                      && size(self.default) > 0)'
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              prompt:
+                description: |-
+                  Prompt is the standing instructions for how the agent operates.
+                  Composed with AgentRun instructions at execution time.
+                type: string
+              skillCards:
+                description: SkillCards references individual SkillCard CRs.
+                items:
+                  description: AgentSkillCardRef references a SkillCard by name.
+                  properties:
+                    ref:
+                      description: Ref is the name of a SkillCard CR in the same namespace.
+                      minLength: 1
+                      type: string
+                  required:
+                  - ref
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - ref
+                x-kubernetes-list-type: map
+              skillCollections:
+                description: SkillCollections references SkillCollection CRs.
+                items:
+                  description: AgentSkillCollectionRef references a SkillCollection
+                    by name.
+                  properties:
+                    ref:
+                      description: Ref is the name of a SkillCollection CR in the
+                        same namespace.
+                      minLength: 1
+                      type: string
+                  required:
+                  - ref
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - ref
+                x-kubernetes-list-type: map
+            required:
+            - gateways
+            - image
+            type: object
+          status:
+            description: AgentStatus defines the observed state of an Agent.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations of the
+                  Agent's state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed
+                  by the controller.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/bundle/manifests/konveyor.io_agentworkflowruns.yaml
+++ b/bundle/manifests/konveyor.io_agentworkflowruns.yaml
@@ -1,0 +1,537 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.21.0
+  creationTimestamp: null
+  name: agentworkflowruns.konveyor.io
+spec:
+  group: konveyor.io
+  names:
+    kind: AgentWorkflowRun
+    listKind: AgentWorkflowRunList
+    plural: agentworkflowruns
+    shortNames:
+    - awr
+    singular: agentworkflowrun
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.workflowRef
+      name: Workflow
+      type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.currentStage
+      name: Current Stage
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          AgentWorkflowRun is a request to execute an AgentWorkflow. It references
+          an AgentWorkflow and carries generic parameters. The controller orchestrates
+          execution: creates an AgentRun per stage, manages cross-stage handoff via
+          committed files on a shared target branch.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              AgentWorkflowRunSpec defines the desired state of an AgentWorkflowRun.
+              The spec is immutable once created — delete and recreate to change values.
+            properties:
+              env:
+                description: |-
+                  Env is a list of additional environment variables to set across
+                  all stages. Passed through to each AgentRun's Sandbox unchanged.
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: |-
+                        Name of the environment variable.
+                        May consist of any printable ASCII characters except '='.
+                      type: string
+                    value:
+                      description: |-
+                        Variable references $(VAR_NAME) are expanded
+                        using the previously defined environment variables in the container and
+                        any service environment variables. If a variable cannot be resolved,
+                        the reference in the input string will be unchanged. Double $$ are reduced
+                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                        Escaped references will never be expanded, regardless of whether the variable
+                        exists or not.
+                        Defaults to "".
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fieldRef:
+                          description: |-
+                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fileKeyRef:
+                          description: |-
+                            FileKeyRef selects a key of the env file.
+                            Requires the EnvFiles feature gate to be enabled.
+                          properties:
+                            key:
+                              description: |-
+                                The key within the env file. An invalid key will prevent the pod from starting.
+                                The keys defined within a source may consist of any printable ASCII characters except '='.
+                                During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                              type: string
+                            optional:
+                              default: false
+                              description: |-
+                                Specify whether the file or its key must be defined. If the file or key
+                                does not exist, then the env var is not published.
+                                If optional is set to true and the specified key does not exist,
+                                the environment variable will not be set in the Pod's containers.
+
+                                If optional is set to false and the specified key does not exist,
+                                an error will be returned during Pod creation.
+                              type: boolean
+                            path:
+                              description: |-
+                                The path within the volume from which to select the file.
+                                Must be relative and may not contain the '..' path or start with '..'.
+                              type: string
+                            volumeName:
+                              description: The name of the volume mount containing
+                                the env file.
+                              type: string
+                          required:
+                          - key
+                          - path
+                          - volumeName
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        resourceFieldRef:
+                          description: |-
+                            Selects a resource of the container: only resources limits and requests
+                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              envFrom:
+                description: |-
+                  EnvFrom is a list of sources to populate environment variables
+                  across all stages. Passed through to each AgentRun's Sandbox.
+                items:
+                  description: EnvFromSource represents the source of a set of ConfigMaps
+                    or Secrets
+                  properties:
+                    configMapRef:
+                      description: The ConfigMap to select from
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the ConfigMap must be defined
+                          type: boolean
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    prefix:
+                      description: |-
+                        Optional text to prepend to the name of each environment variable.
+                        May consist of any printable ASCII characters except '='.
+                      type: string
+                    secretRef:
+                      description: The Secret to select from
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the Secret must be defined
+                          type: boolean
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  type: object
+                type: array
+              gateway:
+                description: |-
+                  Gateway selects the Gateway (provider/model combination) for all
+                  stages. Individual stages may override this selection in the future.
+                minLength: 1
+                type: string
+              params:
+                description: Params supplies values for Agent parameters across all
+                  stages.
+                items:
+                  description: ParamValue supplies a value for a declared Agent parameter.
+                  properties:
+                    name:
+                      description: Name is the parameter name, matching an Agent param
+                        declaration.
+                      minLength: 1
+                      type: string
+                    value:
+                      description: Value is the parameter value.
+                      type: string
+                  required:
+                  - name
+                  - value
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              workflowRef:
+                description: WorkflowRef is the name of the AgentWorkflow CR to execute.
+                minLength: 1
+                type: string
+            required:
+            - workflowRef
+            type: object
+            x-kubernetes-validations:
+            - message: spec is immutable
+              rule: self == oldSelf
+          status:
+            description: AgentWorkflowRunStatus defines the observed state of an AgentWorkflowRun.
+            properties:
+              completionTime:
+                description: CompletionTime is the time the workflow run finished.
+                format: date-time
+                type: string
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations of the
+                  AgentWorkflowRun's state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              currentStage:
+                description: CurrentStage is the name of the currently executing stage.
+                type: string
+              guide:
+                description: |-
+                  Guide snapshots the AgentWorkflow guide at initialization time, so
+                  mid-run edits do not change it for stages still to run (#87).
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              params:
+                description: |-
+                  Params snapshots the AgentWorkflow's workflow-level parameter
+                  declarations at initialization time, so coercion of the run's
+                  supplied values stays stable across a mid-run workflow edit (#87).
+                items:
+                  description: |-
+                    Param declares a typed parameter that an Agent or AgentWorkflow
+                    accepts. A run (AgentRun / AgentWorkflowRun) supplies values via
+                    ParamValue. Resolved values are delivered to the Sandbox in
+                    /run/konveyor/params.json (see ADR 0009) and may be referenced in
+                    prompt text with $(agent.<name>) / $(workflow.<name>).
+                  properties:
+                    default:
+                      description: Default is the default value if not supplied by
+                        a run.
+                      type: string
+                    description:
+                      description: Description explains the purpose of the parameter.
+                      type: string
+                    name:
+                      description: |-
+                        Name is the parameter name. Referenced in prompt text as
+                        $(agent.<name>) or $(workflow.<name>) and delivered in
+                        params.json under the corresponding section.
+                      minLength: 1
+                      pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                      type: string
+                    required:
+                      description: |-
+                        Required indicates whether the parameter must be supplied.
+                        A parameter with a default is never required.
+                      type: boolean
+                    type:
+                      default: string
+                      description: |-
+                        Type is the parameter type. Controls JSON coercion in
+                        params.json: number as a JSON number, boolean as a JSON boolean,
+                        string as a JSON string.
+                      enum:
+                      - string
+                      - number
+                      - boolean
+                      type: string
+                  required:
+                  - name
+                  type: object
+                  x-kubernetes-validations:
+                  - message: a parameter with a default value cannot be required
+                    rule: '!(has(self.required) && self.required && has(self.default)
+                      && size(self.default) > 0)'
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              phase:
+                default: Pending
+                description: Phase is the current phase of the overall workflow run.
+                enum:
+                - Pending
+                - Running
+                - Succeeded
+                - Failed
+                type: string
+              stages:
+                description: |-
+                  Stages tracks the status of each stage, and snapshots each stage's
+                  definition at initialization time (#87).
+                items:
+                  description: |-
+                    AgentWorkflowRunStageStatus tracks the status of a single stage within
+                    a workflow run.
+                  properties:
+                    agentRef:
+                      description: AgentRef is the snapshotted Agent name for this
+                        stage.
+                      type: string
+                    agentRunName:
+                      description: AgentRunName is the name of the AgentRun CR created
+                        for this stage.
+                      type: string
+                    execution:
+                      description: Execution is the snapshotted stage execution override.
+                      properties:
+                        maxCost:
+                          description: |-
+                            MaxCost is the maximum cumulative cost in USD before wind-down,
+                            as a decimal string (e.g. "10.00"). USD only: the enforcement
+                            threshold must match the currency of reported usage, which is USD
+                            across the supported runtimes. Reported cost may carry an ISO 4217
+                            currency; this threshold does not.
+                          pattern: ^[0-9]+(\.[0-9]{1,2})?$
+                          type: string
+                        maxTurns:
+                          description: |-
+                            MaxTurns is the maximum number of turns before wind-down. The unit
+                            is runtime-defined (e.g. Goose counts turns without user input).
+                          minimum: 1
+                          type: integer
+                        mode:
+                          description: Mode is the supervision policy for tool calls.
+                            Defaults to auto.
+                          enum:
+                          - auto
+                          - approve
+                          type: string
+                      type: object
+                    instructions:
+                      description: Instructions is the snapshotted stage instruction
+                        text.
+                      type: string
+                    name:
+                      description: Name is the stage name, matching a stage in the
+                        AgentWorkflow.
+                      type: string
+                    phase:
+                      description: Phase is the current phase of this stage.
+                      enum:
+                      - Pending
+                      - Running
+                      - Succeeded
+                      - Failed
+                      type: string
+                  required:
+                  - name
+                  - phase
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              startTime:
+                description: StartTime is the time the workflow run started.
+                format: date-time
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/bundle/manifests/konveyor.io_agentworkflows.yaml
+++ b/bundle/manifests/konveyor.io_agentworkflows.yaml
@@ -1,0 +1,272 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.21.0
+  creationTimestamp: null
+  name: agentworkflows.konveyor.io
+spec:
+  group: konveyor.io
+  names:
+    kind: AgentWorkflow
+    listKind: AgentWorkflowList
+    plural: agentworkflows
+    shortNames:
+    - aw
+    singular: agentworkflow
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          AgentWorkflow is a reusable workflow combining a high-level guide with an
+          ordered sequence of stages. Each stage references an Agent and carries
+          instructions. An AgentWorkflow is a template — creating one does not
+          execute anything.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AgentWorkflowSpec defines the desired state of an AgentWorkflow.
+            properties:
+              guide:
+                description: |-
+                  Guide is a high-level guide providing ambient context for all stages.
+                  Written as a context file in the workspace so each agent understands
+                  where its work fits in the bigger picture.
+                type: string
+              params:
+                description: |-
+                  Params declares workflow-level typed parameters. An
+                  AgentWorkflowRun supplies values; the controller renders them into
+                  the workflow section of params.json and into $(workflow.<name>)
+                  references in the guide and stage instructions (ADR 0009).
+                items:
+                  description: |-
+                    Param declares a typed parameter that an Agent or AgentWorkflow
+                    accepts. A run (AgentRun / AgentWorkflowRun) supplies values via
+                    ParamValue. Resolved values are delivered to the Sandbox in
+                    /run/konveyor/params.json (see ADR 0009) and may be referenced in
+                    prompt text with $(agent.<name>) / $(workflow.<name>).
+                  properties:
+                    default:
+                      description: Default is the default value if not supplied by
+                        a run.
+                      type: string
+                    description:
+                      description: Description explains the purpose of the parameter.
+                      type: string
+                    name:
+                      description: |-
+                        Name is the parameter name. Referenced in prompt text as
+                        $(agent.<name>) or $(workflow.<name>) and delivered in
+                        params.json under the corresponding section.
+                      minLength: 1
+                      pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                      type: string
+                    required:
+                      description: |-
+                        Required indicates whether the parameter must be supplied.
+                        A parameter with a default is never required.
+                      type: boolean
+                    type:
+                      default: string
+                      description: |-
+                        Type is the parameter type. Controls JSON coercion in
+                        params.json: number as a JSON number, boolean as a JSON boolean,
+                        string as a JSON string.
+                      enum:
+                      - string
+                      - number
+                      - boolean
+                      type: string
+                  required:
+                  - name
+                  type: object
+                  x-kubernetes-validations:
+                  - message: a parameter with a default value cannot be required
+                    rule: '!(has(self.required) && self.required && has(self.default)
+                      && size(self.default) > 0)'
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              stages:
+                description: |-
+                  Stages is the ordered sequence of stages. Each stage references an
+                  Agent and carries instructions. Stages execute sequentially, sharing
+                  the same target branch. Cross-stage continuity comes from committed
+                  handoff files.
+                items:
+                  description: |-
+                    AgentWorkflowStage defines one stage in a workflow.
+                    Each stage references an Agent and carries instructions.
+                  properties:
+                    agentRef:
+                      description: AgentRef is the name of the Agent CR to execute
+                        for this stage.
+                      minLength: 1
+                      type: string
+                    execution:
+                      description: |-
+                        Execution overrides the stage Agent's default supervision mode and
+                        budget limits. The AgentWorkflowRun controller resolves these
+                        (stage override, else Agent default) and stamps the result onto the
+                        stage's AgentRun (ADR 0018). Unset fields fall back to the Agent.
+                      properties:
+                        maxCost:
+                          description: |-
+                            MaxCost is the maximum cumulative cost in USD before wind-down,
+                            as a decimal string (e.g. "10.00"). USD only: the enforcement
+                            threshold must match the currency of reported usage, which is USD
+                            across the supported runtimes. Reported cost may carry an ISO 4217
+                            currency; this threshold does not.
+                          pattern: ^[0-9]+(\.[0-9]{1,2})?$
+                          type: string
+                        maxTurns:
+                          description: |-
+                            MaxTurns is the maximum number of turns before wind-down. The unit
+                            is runtime-defined (e.g. Goose counts turns without user input).
+                          minimum: 1
+                          type: integer
+                        mode:
+                          description: Mode is the supervision policy for tool calls.
+                            Defaults to auto.
+                          enum:
+                          - auto
+                          - approve
+                          type: string
+                      type: object
+                    instructions:
+                      description: |-
+                        Instructions are task-specific instructions for this stage.
+                        Composed with the Agent's prompt at execution time. Supports
+                        $(agent.<name>) / $(workflow.<name>) substitution.
+                      type: string
+                    name:
+                      description: |-
+                        Name is the stage name, unique within the workflow.
+                        Must be a valid Kubernetes label value (lowercase alphanumeric,
+                        hyphens, dots, max 63 chars) since it is used in labels on
+                        child AgentRun resources.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([a-z0-9\-\.]*[a-z0-9])?$
+                      type: string
+                  required:
+                  - agentRef
+                  - name
+                  type: object
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+            required:
+            - stages
+            type: object
+          status:
+            description: AgentWorkflowStatus defines the observed state of an AgentWorkflow.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations of the
+                  AgentWorkflow's state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed
+                  by the controller.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/bundle/manifests/konveyor.io_gateways.yaml
+++ b/bundle/manifests/konveyor.io_gateways.yaml
@@ -1,0 +1,220 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.21.0
+  creationTimestamp: null
+  name: gateways.konveyor.io
+spec:
+  group: konveyor.io
+  names:
+    kind: Gateway
+    listKind: GatewayList
+    plural: gateways
+    shortNames:
+    - gw
+    singular: gateway
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.endpoint
+      name: Endpoint
+      type: string
+    - jsonPath: .spec.model.name
+      name: Model
+      type: string
+    - jsonPath: .status.connectionVerified
+      name: Verified
+      type: boolean
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          Gateway is an LLM service endpoint serving exactly one provider/model
+          combination. Each Gateway has credentials and a single model declaration.
+          This mirrors the OpenShell gateway model where one gateway = one model.
+          The controller verifies connectivity on create/update.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: GatewaySpec defines the desired state of a Gateway.
+            properties:
+              credentialRef:
+                description: CredentialRef references a Secret containing the API
+                  credential.
+                properties:
+                  key:
+                    description: |-
+                      Key is the key within the Secret that contains the credential value.
+                      When set, the credential is a single value (e.g. a bearer token) and
+                      is injected into sandbox containers as KONVEYOR_LLM_API_KEY.
+                      When omitted, the credential spans multiple environment variables
+                      (e.g. AWS SigV4: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY,
+                      AWS_REGION) and the whole Secret is exposed to the sandbox container
+                      via envFrom, with the Secret's keys as the variable names.
+                    minLength: 1
+                    type: string
+                  secretName:
+                    description: SecretName is the name of the Secret in the same
+                      namespace.
+                    minLength: 1
+                    type: string
+                required:
+                - secretName
+                type: object
+              endpoint:
+                description: Endpoint is the base URL of the LLM service.
+                minLength: 1
+                type: string
+              model:
+                description: |-
+                  Model is the model served by this gateway. Each Gateway serves
+                  exactly one provider/model combination, mirroring the OpenShell
+                  gateway model where one gateway = one model.
+                properties:
+                  contextWindow:
+                    description: |-
+                      ContextWindow is the maximum context window size in tokens.
+                      Used to validate that an Agent's always-loaded rules fit within budget.
+                    format: int64
+                    minimum: 1
+                    type: integer
+                  name:
+                    description: Name is the model identifier (e.g. "claude-sonnet-4-20250514",
+                      "gpt-4o").
+                    minLength: 1
+                    type: string
+                  tier:
+                    description: |-
+                      Tier is an optional label for the model's capability tier
+                      (e.g. "premium", "efficient").
+                    type: string
+                required:
+                - contextWindow
+                - name
+                type: object
+              provider:
+                description: |-
+                  Provider is the runtime provider identifier (e.g. "anthropic",
+                  "openai", "gcp-vertex-ai"). Injected as KONVEYOR_LLM_PROVIDER
+                  so the harness can map credentials to provider-specific env vars.
+                  This is a pre-OpenShell shim — when OpenShell is integrated,
+                  inference.local eliminates the need for provider-specific
+                  credential mapping and this field is removed.
+                minLength: 1
+                type: string
+            required:
+            - credentialRef
+            - endpoint
+            - model
+            - provider
+            type: object
+          status:
+            description: GatewayStatus defines the observed state of a Gateway.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations of the
+                  Gateway's state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              connectionVerified:
+                description: |-
+                  ConnectionVerified indicates whether the controller has successfully
+                  verified connectivity to the gateway endpoint.
+                type: boolean
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed
+                  by the controller.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/bundle/manifests/konveyor.io_skillcards.yaml
+++ b/bundle/manifests/konveyor.io_skillcards.yaml
@@ -1,0 +1,217 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.21.0
+  creationTimestamp: null
+  name: skillcards.konveyor.io
+spec:
+  group: konveyor.io
+  names:
+    kind: SkillCard
+    listKind: SkillCardList
+    plural: skillcards
+    shortNames:
+    - skc
+    singular: skillcard
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.type
+      name: Type
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          SkillCard is an individual agent capability or behavioral constraint.
+          It follows the skillimage.io/v1alpha1 SkillCard format and supports three
+          source types: OCI image ref, git source URL, or inline markdown. All three
+          converge to a resolved OCI image ref in status.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              SkillCardSpec defines the desired state of a SkillCard.
+              Exactly one of Image, Source, or Inline must be set.
+            properties:
+              description:
+                description: Description is a short description of what the skill
+                  does.
+                type: string
+              displayName:
+                description: DisplayName is a human-readable name for the skill.
+                type: string
+              image:
+                description: Image is an OCI image reference for a pre-built skill
+                  artifact.
+                type: string
+              inline:
+                description: |-
+                  Inline is raw markdown content for the skill, delivered as a ConfigMap.
+                  A ConfigMap key cannot hold a path separator, so an inline skill is a
+                  single SKILL.md and cannot ship supporting files.
+                type: string
+              ref:
+                description: |-
+                  Ref is the branch, tag or commit to check out from Source. Empty
+                  clones the default branch, which makes the run unreproducible, and the
+                  loader warns when it is unset.
+                  Only meaningful with Source.
+                type: string
+              source:
+                description: |-
+                  Source is a git URL. The skill loader clones it at pod start; nothing
+                  is built.
+                type: string
+              subPath:
+                description: |-
+                  SubPath selects one skill from a source that holds several, naming its
+                  directory within the image or repository. A SkillCard is always one
+                  skill, so a source holding several without a SubPath is an error.
+                  Only meaningful with Image or Source.
+                type: string
+              tags:
+                description: Tags are labels for categorization and discovery.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              type:
+                default: skill
+                description: |-
+                  Type is this skill's load policy. Defaults to "skill".
+
+                  It lives here rather than in SKILL.md: the Agent Skills spec's field set
+                  is closed, so declaring it in content would break the format (ADR 0015).
+                enum:
+                - skill
+                - rule
+                type: string
+              version:
+                description: Version is the semantic version of the skill.
+                type: string
+            type: object
+            x-kubernetes-validations:
+            - message: exactly one of image, source, or inline must be set
+              rule: '(has(self.image) ? 1 : 0) + (has(self.source) ? 1 : 0) + (has(self.inline)
+                ? 1 : 0) == 1'
+          status:
+            description: SkillCardStatus defines the observed state of a SkillCard.
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the SkillCard's state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              deliveryMode:
+                description: |-
+                  DeliveryMode is how this skill reaches the pod, so that "not resolved
+                  yet" is distinguishable from "resolved, just not to an image".
+                enum:
+                - image
+                - inline
+                - source
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              resolvedImage:
+                description: |-
+                  ResolvedImage is the OCI image reference for the resolved skill artifact.
+                  Only an image source resolves to one; for inline and git it stays empty
+                  because there is no image, so read DeliveryMode rather than inferring
+                  from this being unset.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/bundle/manifests/konveyor.io_skillcollections.yaml
+++ b/bundle/manifests/konveyor.io_skillcollections.yaml
@@ -1,0 +1,232 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.21.0
+  creationTimestamp: null
+  name: skillcollections.konveyor.io
+spec:
+  group: konveyor.io
+  names:
+    kind: SkillCollection
+    listKind: SkillCollectionList
+    plural: skillcollections
+    shortNames:
+    - scol
+    singular: skillcollection
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          SkillCollection is a group of skills, following the skillimage.io/v1alpha1
+          SkillCollection format. Each entry references a skill by OCI image ref,
+          git source URL, or SkillCard CR name. The controller creates SkillCard CRs
+          for git-sourced entries and reports readiness when all children are resolved.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              SkillCollectionSpec defines the desired state of a SkillCollection.
+              Set either Image or Skills.
+            properties:
+              image:
+                description: |-
+                  Image is an OCI image holding one or more skills. The controller
+                  enumerates it with a short-lived Job and creates a SkillCard per skill
+                  it finds, owned by this collection, so a user points at a source once
+                  rather than writing a card per skill.
+                type: string
+              skills:
+                description: |-
+                  Skills is an explicit list, for grouping skills that already exist.
+
+                  MinItems, because the rule above is satisfied by a list that is present
+                  and empty: without it `skills: []` is admitted and the collection is
+                  simply never Ready, where the field used to be rejected outright.
+                items:
+                  description: |-
+                    SkillCollectionSkillRef references a skill by SkillCard CR name,
+                    OCI image ref, or git source URL. Exactly one of SkillCardRef,
+                    Image, or Source must be set.
+                  properties:
+                    image:
+                      description: Image is an OCI image reference for a pre-built
+                        skill artifact.
+                      type: string
+                    name:
+                      description: Name is the local name for this skill within the
+                        collection.
+                      minLength: 1
+                      type: string
+                    ref:
+                      description: |-
+                        Ref is the branch, tag or commit to check out from Source. Empty
+                        clones the default branch, leaving the run unreproducible.
+                        Only meaningful with Source.
+                      type: string
+                    skillCardRef:
+                      description: SkillCardRef is the name of a SkillCard CR in the
+                        same namespace.
+                      type: string
+                    source:
+                      description: Source is a git URL. The skill loader clones it
+                        at pod start.
+                      type: string
+                    subPath:
+                      description: |-
+                        SubPath selects one skill from a source holding several, naming its
+                        directory within the image or repository.
+                        Only meaningful with Image or Source.
+                      type: string
+                    type:
+                      description: |-
+                        Type is the load policy for this entry's skill. Defaults to "skill".
+                        Ignored when SkillCardRef is set, since the card carries its own.
+                      enum:
+                      - skill
+                      - rule
+                      type: string
+                  required:
+                  - name
+                  type: object
+                  x-kubernetes-validations:
+                  - message: exactly one of skillCardRef, image, or source must be
+                      set
+                    rule: '(has(self.skillCardRef) ? 1 : 0) + (has(self.image) ? 1
+                      : 0) + (has(self.source) ? 1 : 0) == 1'
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              type:
+                description: |-
+                  Type is the load policy applied to every skill enumerated from Image.
+                  Defaults to "skill". Per-skill policy within one image is not yet
+                  expressible; see ADR 0015.
+                enum:
+                - skill
+                - rule
+                type: string
+              version:
+                description: Version is the semantic version of the collection.
+                type: string
+            type: object
+            x-kubernetes-validations:
+            - message: set either image or skills, not both
+              rule: has(self.image) != has(self.skills)
+          status:
+            description: SkillCollectionStatus defines the observed state of a SkillCollection.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations of the
+                  SkillCollection's state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              resolvedSkills:
+                description: |-
+                  ResolvedSkills names the SkillCards this collection owns, whether
+                  enumerated from Image or listed explicitly.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/docs/development.md
+++ b/docs/development.md
@@ -8,7 +8,7 @@ Alternatively, it is possible to test operators locally outside a cluster but is
 
 Before you begin, the following tools need to be installed in your dev system:
 
-* [__k8s v1.22+__](https://kubernetes.io/) or [__OpenShift 4.9+__](https://www.openshift.com/)
+* [__k8s v1.25+__](https://kubernetes.io/) or [__OpenShift 4.12+__](https://www.openshift.com/)
 * [__Operator SDK__](https://sdk.operatorframework.io/docs/installation/)
 * [__Operator Lifecycle Manager (OLM) support__](https://olm.operatorframework.io/) (minikube/k8s clusters)
 * [__OPM__](https://github.com/operator-framework/operator-registry/)

--- a/hack/install-konveyor.sh
+++ b/hack/install-konveyor.sh
@@ -17,6 +17,16 @@ KAI_LLM_PROVIDER="${KAI_LLM_PROVIDER:-}"
 KAI_LLM_BASEURL="${KAI_LLM_BASEURL:-}"
 USE_HELM="${USE_HELM:-false}"
 
+# Agent Sandbox is a prerequisite for the agentic controller (it provides the
+# sandboxes.agents.x-k8s.io CRD). It is not an operator-managed operand, so this
+# optional step installs it for development/testing. Off by default.
+INSTALL_AGENT_SANDBOX="${INSTALL_AGENT_SANDBOX:-false}"
+AGENT_SANDBOX_VERSION="${AGENT_SANDBOX_VERSION:-v1.0.0}"
+# Which released manifest to apply: sandbox.yaml (core) or
+# sandbox-with-extensions.yaml (core + extensions). Core is enough for the
+# agentic controller.
+AGENT_SANDBOX_MANIFEST="${AGENT_SANDBOX_MANIFEST:-sandbox.yaml}"
+
 # Global timeout configuration - entire script must complete within this time
 GLOBAL_TIMEOUT_SECONDS="${GLOBAL_TIMEOUT_SECONDS:-600}"  # 10 minutes default
 SCRIPT_START_TIME=$(date +%s)
@@ -172,6 +182,24 @@ debug() {
 trap 'debug' ERR
 
 # Function to deploy bundle - waits for OLM operators as precondition
+# Optionally install Agent Sandbox (a prerequisite for the agentic controller).
+# Applies the pre-rendered release manifest and waits for its controller.
+start_agent_sandbox() {
+  echo "=== Installing Agent Sandbox ${AGENT_SANDBOX_VERSION} (${AGENT_SANDBOX_MANIFEST}) ==="
+  local url="https://github.com/kubernetes-sigs/agent-sandbox/releases/download/${AGENT_SANDBOX_VERSION}/${AGENT_SANDBOX_MANIFEST}"
+  if ! kubectl apply -f "${url}"; then
+    echo "Error: Failed to apply Agent Sandbox manifest from ${url}"
+    return 1
+  fi
+  echo "Waiting for the Agent Sandbox controller to become available..."
+  if ! kubectl wait --namespace agent-sandbox-system \
+    --for=condition=Available deployment/agent-sandbox-controller --timeout=120s; then
+    echo "Error: Agent Sandbox controller did not become ready"
+    return 1
+  fi
+  echo "Agent Sandbox is ready"
+}
+
 # Discover the namespace where OLM is running. Self-installed OLM (kind/minikube)
 # uses 'olm', while OpenShift ships it in 'openshift-operator-lifecycle-manager'.
 # The packageserver CSV lives in the OLM namespace in both cases.
@@ -467,6 +495,12 @@ echo "=== PHASE 1: Starting All Components ==="
 
 # Create namespace early if it doesn't exist
 kubectl create namespace "${NAMESPACE}" 2>/dev/null || true
+
+# Install the Agent Sandbox prerequisite first (opt-in) so its CRD is present
+# before the operator reconciles a Tackle CR with agentic_enabled=true.
+if [ "${INSTALL_AGENT_SANDBOX}" == "true" ]; then
+  start_agent_sandbox
+fi
 
 if [ "${USE_HELM}" == "true" ]; then
   # Helm-based installation

--- a/hack/install-konveyor.sh
+++ b/hack/install-konveyor.sh
@@ -172,6 +172,14 @@ debug() {
 trap 'debug' ERR
 
 # Function to deploy bundle - waits for OLM operators as precondition
+# Discover the namespace where OLM is running. Self-installed OLM (kind/minikube)
+# uses 'olm', while OpenShift ships it in 'openshift-operator-lifecycle-manager'.
+# The packageserver CSV lives in the OLM namespace in both cases.
+get_olm_namespace() {
+  kubectl get clusterserviceversions.operators.coreos.com --all-namespaces 2>/dev/null \
+    | awk '/packageserver/ {print $1; exit}'
+}
+
 start_bundle() {
   echo "=== Starting Bundle Deployment ==="
   
@@ -184,17 +192,19 @@ start_bundle() {
       return 1
     fi
     
-    # Check if OLM namespace exists and operators are ready
-    if kubectl get namespace olm >/dev/null 2>&1; then
-      echo "  OLM namespace exists, checking if operators are ready..."
-      if kubectl wait --for=condition=Available deployment/olm-operator deployment/catalog-operator -n olm --timeout=30s 2>/dev/null; then
+    # Discover the OLM namespace (works for both self-installed OLM and OpenShift)
+    local olm_namespace
+    olm_namespace=$(get_olm_namespace)
+    if [ -n "${olm_namespace}" ]; then
+      echo "  OLM detected in namespace '${olm_namespace}', checking if operators are ready..."
+      if kubectl wait --for=condition=Available deployment/olm-operator deployment/catalog-operator -n "${olm_namespace}" --timeout=30s 2>/dev/null; then
         echo "  OLM operators are ready"
         break
       else
         echo "  OLM operators not ready yet, will retry in 5s..."
       fi
     else
-      echo "  OLM namespace doesn't exist yet, will retry in 5s..."
+      echo "  OLM not detected yet, will retry in 5s..."
     fi
     sleep 5
   done
@@ -410,7 +420,7 @@ validate_full_stack() {
   
   # Get OLM namespace
   local olm_namespace
-  olm_namespace=$(kubectl get clusterserviceversions.operators.coreos.com --all-namespaces | grep packageserver | awk '{print $1}')
+  olm_namespace=$(get_olm_namespace)
   
   # Check if namespace was found
   if [ -z "${olm_namespace}" ]; then

--- a/helm/templates/crds/konveyor.io_agentruns.yaml
+++ b/helm/templates/crds/konveyor.io_agentruns.yaml
@@ -1,0 +1,529 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.21.0
+  name: agentruns.konveyor.io
+spec:
+  group: konveyor.io
+  names:
+    kind: AgentRun
+    listKind: AgentRunList
+    plural: agentruns
+    shortNames:
+    - ar
+    singular: agentrun
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.agentRef
+      name: Agent
+      type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.duration
+      name: Duration
+      priority: 1
+      type: integer
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          AgentRun is a request to execute a single Agent with specific selections.
+          It references an Agent, selects a gateway, carries instructions and
+          key-value parameters (delivered via /run/konveyor/params.json and
+          referenced in prompt text as $(agent.<name>) / $(workflow.<name>) — ADR
+          0009). The controller validates, resolves skills to ImageVolumes, creates
+          a Sandbox, and tracks status to completion.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              AgentRunSpec defines the desired state of an AgentRun.
+              The spec is immutable once created — delete and recreate to change values.
+            properties:
+              agentRef:
+                description: AgentRef is the name of the Agent CR to execute.
+                minLength: 1
+                type: string
+              env:
+                description: |-
+                  Env is a list of additional environment variables to set in the
+                  Sandbox container. Passed through to the Sandbox unchanged.
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: |-
+                        Name of the environment variable.
+                        May consist of any printable ASCII characters except '='.
+                      type: string
+                    value:
+                      description: |-
+                        Variable references $(VAR_NAME) are expanded
+                        using the previously defined environment variables in the container and
+                        any service environment variables. If a variable cannot be resolved,
+                        the reference in the input string will be unchanged. Double $$ are reduced
+                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                        Escaped references will never be expanded, regardless of whether the variable
+                        exists or not.
+                        Defaults to "".
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fieldRef:
+                          description: |-
+                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fileKeyRef:
+                          description: |-
+                            FileKeyRef selects a key of the env file.
+                            Requires the EnvFiles feature gate to be enabled.
+                          properties:
+                            key:
+                              description: |-
+                                The key within the env file. An invalid key will prevent the pod from starting.
+                                The keys defined within a source may consist of any printable ASCII characters except '='.
+                                During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                              type: string
+                            optional:
+                              default: false
+                              description: |-
+                                Specify whether the file or its key must be defined. If the file or key
+                                does not exist, then the env var is not published.
+                                If optional is set to true and the specified key does not exist,
+                                the environment variable will not be set in the Pod's containers.
+
+                                If optional is set to false and the specified key does not exist,
+                                an error will be returned during Pod creation.
+                              type: boolean
+                            path:
+                              description: |-
+                                The path within the volume from which to select the file.
+                                Must be relative and may not contain the '..' path or start with '..'.
+                              type: string
+                            volumeName:
+                              description: The name of the volume mount containing
+                                the env file.
+                              type: string
+                          required:
+                          - key
+                          - path
+                          - volumeName
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        resourceFieldRef:
+                          description: |-
+                            Selects a resource of the container: only resources limits and requests
+                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              envFrom:
+                description: |-
+                  EnvFrom is a list of sources to populate environment variables in
+                  the Sandbox container. Passed through to the Sandbox unchanged.
+                items:
+                  description: EnvFromSource represents the source of a set of ConfigMaps
+                    or Secrets
+                  properties:
+                    configMapRef:
+                      description: The ConfigMap to select from
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the ConfigMap must be defined
+                          type: boolean
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    prefix:
+                      description: |-
+                        Optional text to prepend to the name of each environment variable.
+                        May consist of any printable ASCII characters except '='.
+                      type: string
+                    secretRef:
+                      description: The Secret to select from
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the Secret must be defined
+                          type: boolean
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  type: object
+                type: array
+              execution:
+                description: |-
+                  Execution carries the resolved supervision mode and budget limits
+                  for this run. For a standalone run these are set by the run
+                  creator (mode) and default from the Agent (limits). For a workflow
+                  stage the AgentWorkflowRun controller stamps the stage-resolved
+                  values here (ADR 0018). Unset fields resolve against the Agent's
+                  Execution defaults; mode resolves to auto when unset everywhere.
+                properties:
+                  maxCost:
+                    description: |-
+                      MaxCost is the maximum cumulative cost in USD before wind-down,
+                      as a decimal string (e.g. "10.00"). USD only: the enforcement
+                      threshold must match the currency of reported usage, which is USD
+                      across the supported runtimes. Reported cost may carry an ISO 4217
+                      currency; this threshold does not.
+                    pattern: ^[0-9]+(\.[0-9]{1,2})?$
+                    type: string
+                  maxTurns:
+                    description: |-
+                      MaxTurns is the maximum number of turns before wind-down. The unit
+                      is runtime-defined (e.g. Goose counts turns without user input).
+                    minimum: 1
+                    type: integer
+                  mode:
+                    description: Mode is the supervision policy for tool calls. Defaults
+                      to auto.
+                    enum:
+                    - auto
+                    - approve
+                    type: string
+                type: object
+              gateway:
+                description: |-
+                  Gateway selects the Gateway (provider/model combination) for this
+                  run. Must be one of the gateways declared on the referenced Agent.
+                minLength: 1
+                type: string
+              gitConfig:
+                description: |-
+                  GitConfig overrides the Agent's git commit identity for this run.
+                  When set it replaces the Agent's GitConfig wholesale (name and email
+                  together); when unset the run uses the Agent's identity, then the
+                  harness default.
+                properties:
+                  userEmail:
+                    description: |-
+                      UserEmail maps to git config user.email for the agent's commits.
+                      Must be a bare address (local@domain) with no angle brackets,
+                      whitespace, or control characters — go-git wraps it in <> unescaped.
+                    maxLength: 254
+                    pattern: ^[^\x00-\x20\x7f<>@]+@[^\x00-\x20\x7f<>@]+\.[^\x00-\x20\x7f<>@]+$
+                    type: string
+                  userName:
+                    description: |-
+                      UserName maps to git config user.name for the agent's commits.
+                      go-git does not escape the identity, so reject angle brackets and
+                      control characters that would corrupt or forge the commit ident.
+                    maxLength: 128
+                    pattern: ^[^\x00-\x1f\x7f<>]+$
+                    type: string
+                type: object
+                x-kubernetes-validations:
+                - message: userName and userEmail must both be set
+                  rule: has(self.userName) && has(self.userEmail)
+              instructions:
+                description: |-
+                  Instructions are task-specific instructions for this run.
+                  Composed with the Agent's prompt at execution time. Supports
+                  $(agent.<name>) / $(workflow.<name>) substitution.
+                type: string
+              params:
+                description: |-
+                  Params supplies values for the Agent's declared parameters.
+                  Resolved values are written to /run/konveyor/params.json in the
+                  Sandbox (see ADR 0009); they are not injected as env vars.
+                items:
+                  description: ParamValue supplies a value for a declared Agent parameter.
+                  properties:
+                    name:
+                      description: Name is the parameter name, matching an Agent param
+                        declaration.
+                      minLength: 1
+                      type: string
+                    value:
+                      description: Value is the parameter value.
+                      type: string
+                  required:
+                  - name
+                  - value
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              workflowParams:
+                description: |-
+                  WorkflowParams carries the resolved, type-coerced workflow-level
+                  parameters for a stage run, as a JSON object stamped by the
+                  AgentWorkflowRun controller (ADR 0018). The AgentRun controller
+                  writes it verbatim to the "workflow" section of params.json and
+                  uses its values for $(workflow.<name>) substitution. Empty for
+                  standalone runs. Coercion happens in the workflow controller,
+                  which owns the AgentWorkflow param declarations.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+            required:
+            - agentRef
+            type: object
+            x-kubernetes-validations:
+            - message: spec is immutable
+              rule: self == oldSelf
+          status:
+            description: AgentRunStatus defines the observed state of an AgentRun.
+            properties:
+              completionTime:
+                description: CompletionTime is the time the Sandbox finished.
+                format: date-time
+                type: string
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations of the
+                  AgentRun's state. Ready tracks the run's overall outcome (False
+                  while in progress with the current step as its reason, True on
+                  success); ACPReady tracks whether the agent's ACP endpoint accepts
+                  connections (see AgentRunConditionACPReady). Succeeded is the
+                  terminal outcome (see AgentRunConditionSucceeded): Unknown while
+                  running, True on clean completion, False with a reason
+                  (Failed, LimitReached) otherwise.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              duration:
+                description: Duration is the wall-clock duration of the run in seconds.
+                format: int64
+                type: integer
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              phase:
+                default: Pending
+                description: |-
+                  Phase is the current phase of the AgentRun. Running means the sandbox
+                  pod is running (the agent process is executing); it says nothing about
+                  whether the agent's ACP endpoint accepts connections yet — that is the
+                  ACPReady condition. A run whose pod finishes before the controller
+                  observes it running may go straight from Pending to a terminal phase.
+                enum:
+                - Pending
+                - Running
+                - Succeeded
+                - Failed
+                type: string
+              sandboxName:
+                description: SandboxName is the name of the Sandbox CR created for
+                  this run.
+                type: string
+              secretKeyRef:
+                description: |-
+                  SecretKeyRef references a Secret containing the ACP authentication key
+                  for connecting to the agent's ACP endpoint. The harness generates
+                  a random key per run and stores it in this Secret.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              startTime:
+                description: |-
+                  StartTime is the time the sandbox pod started running (the Sandbox
+                  creation time if the pod finished before the controller saw it run).
+                format: date-time
+                type: string
+              terminationData:
+                description: |-
+                  TerminationData is the raw JSON the harness wrote to the pod's
+                  termination message (/dev/termination-log) on exit — typically a
+                  usage/cost report. The controller copies it verbatim and never
+                  interprets it; platform-specific UIs read the harness's schema
+                  (ADR 0011/0018). Absent if the harness wrote nothing parseable.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/helm/templates/crds/konveyor.io_agents.yaml
+++ b/helm/templates/crds/konveyor.io_agents.yaml
@@ -1,0 +1,303 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.21.0
+  name: agents.konveyor.io
+spec:
+  group: konveyor.io
+  names:
+    kind: Agent
+    listKind: AgentList
+    plural: agents
+    shortNames:
+    - ag
+    singular: agent
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.image
+      name: Image
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          Agent is a capability definition declaring what is available for execution.
+          It references SkillCards, SkillCollections, Gateways, a container image,
+          a prompt, and typed parameters. An Agent does not select a specific model —
+          gateway selection happens at execution time via AgentRun.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AgentSpec defines the desired state of an Agent.
+            properties:
+              execution:
+                description: |-
+                  Execution declares the default budget limits (maxTurns, maxCost)
+                  for runs of this Agent. Runs and workflow stages may override
+                  these; the AgentRun carries the resolved values (ADR 0018). The
+                  Agent does not declare mode — mode is an execution-time concern set
+                  on the AgentRun or stage (ADR 0011/0018).
+                properties:
+                  maxCost:
+                    description: |-
+                      MaxCost is the maximum cumulative cost in USD before wind-down,
+                      as a decimal string (e.g. "10.00"). USD only: the enforcement
+                      threshold must match the currency of reported usage, which is USD
+                      across the supported runtimes. Reported cost may carry an ISO 4217
+                      currency; this threshold does not.
+                    pattern: ^[0-9]+(\.[0-9]{1,2})?$
+                    type: string
+                  maxTurns:
+                    description: |-
+                      MaxTurns is the maximum number of turns before wind-down. The unit
+                      is runtime-defined (e.g. Goose counts turns without user input).
+                    minimum: 1
+                    type: integer
+                type: object
+              gateways:
+                description: |-
+                  Gateways is the set of gateways (provider/model combinations)
+                  available for runs. At least one gateway must be specified.
+                items:
+                  description: AgentGatewayRef references a Gateway by name.
+                  properties:
+                    ref:
+                      description: Ref is the name of a Gateway CR in the same namespace.
+                      minLength: 1
+                      type: string
+                  required:
+                  - ref
+                  type: object
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - ref
+                x-kubernetes-list-type: map
+              gitConfig:
+                description: |-
+                  GitConfig sets the default git commit identity for the agent's
+                  commits. An AgentRun may override it per run. When unset, commits
+                  use the harness default identity.
+                properties:
+                  userEmail:
+                    description: |-
+                      UserEmail maps to git config user.email for the agent's commits.
+                      Must be a bare address (local@domain) with no angle brackets,
+                      whitespace, or control characters — go-git wraps it in <> unescaped.
+                    maxLength: 254
+                    pattern: ^[^\x00-\x20\x7f<>@]+@[^\x00-\x20\x7f<>@]+\.[^\x00-\x20\x7f<>@]+$
+                    type: string
+                  userName:
+                    description: |-
+                      UserName maps to git config user.name for the agent's commits.
+                      go-git does not escape the identity, so reject angle brackets and
+                      control characters that would corrupt or forge the commit ident.
+                    maxLength: 128
+                    pattern: ^[^\x00-\x1f\x7f<>]+$
+                    type: string
+                type: object
+                x-kubernetes-validations:
+                - message: userName and userEmail must both be set
+                  rule: has(self.userName) && has(self.userEmail)
+              image:
+                description: Image is the container image carrying the agent runtime
+                  and toolchains.
+                minLength: 1
+                type: string
+              params:
+                description: Params declares the typed parameters this Agent accepts.
+                items:
+                  description: |-
+                    Param declares a typed parameter that an Agent or AgentWorkflow
+                    accepts. A run (AgentRun / AgentWorkflowRun) supplies values via
+                    ParamValue. Resolved values are delivered to the Sandbox in
+                    /run/konveyor/params.json (see ADR 0009) and may be referenced in
+                    prompt text with $(agent.<name>) / $(workflow.<name>).
+                  properties:
+                    default:
+                      description: Default is the default value if not supplied by
+                        a run.
+                      type: string
+                    description:
+                      description: Description explains the purpose of the parameter.
+                      type: string
+                    name:
+                      description: |-
+                        Name is the parameter name. Referenced in prompt text as
+                        $(agent.<name>) or $(workflow.<name>) and delivered in
+                        params.json under the corresponding section.
+                      minLength: 1
+                      pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                      type: string
+                    required:
+                      description: |-
+                        Required indicates whether the parameter must be supplied.
+                        A parameter with a default is never required.
+                      type: boolean
+                    type:
+                      default: string
+                      description: |-
+                        Type is the parameter type. Controls JSON coercion in
+                        params.json: number as a JSON number, boolean as a JSON boolean,
+                        string as a JSON string.
+                      enum:
+                      - string
+                      - number
+                      - boolean
+                      type: string
+                  required:
+                  - name
+                  type: object
+                  x-kubernetes-validations:
+                  - message: a parameter with a default value cannot be required
+                    rule: '!(has(self.required) && self.required && has(self.default)
+                      && size(self.default) > 0)'
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              prompt:
+                description: |-
+                  Prompt is the standing instructions for how the agent operates.
+                  Composed with AgentRun instructions at execution time.
+                type: string
+              skillCards:
+                description: SkillCards references individual SkillCard CRs.
+                items:
+                  description: AgentSkillCardRef references a SkillCard by name.
+                  properties:
+                    ref:
+                      description: Ref is the name of a SkillCard CR in the same namespace.
+                      minLength: 1
+                      type: string
+                  required:
+                  - ref
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - ref
+                x-kubernetes-list-type: map
+              skillCollections:
+                description: SkillCollections references SkillCollection CRs.
+                items:
+                  description: AgentSkillCollectionRef references a SkillCollection
+                    by name.
+                  properties:
+                    ref:
+                      description: Ref is the name of a SkillCollection CR in the
+                        same namespace.
+                      minLength: 1
+                      type: string
+                  required:
+                  - ref
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - ref
+                x-kubernetes-list-type: map
+            required:
+            - gateways
+            - image
+            type: object
+          status:
+            description: AgentStatus defines the observed state of an Agent.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations of the
+                  Agent's state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed
+                  by the controller.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/helm/templates/crds/konveyor.io_agentworkflowruns.yaml
+++ b/helm/templates/crds/konveyor.io_agentworkflowruns.yaml
@@ -1,0 +1,531 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.21.0
+  name: agentworkflowruns.konveyor.io
+spec:
+  group: konveyor.io
+  names:
+    kind: AgentWorkflowRun
+    listKind: AgentWorkflowRunList
+    plural: agentworkflowruns
+    shortNames:
+    - awr
+    singular: agentworkflowrun
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.workflowRef
+      name: Workflow
+      type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.currentStage
+      name: Current Stage
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          AgentWorkflowRun is a request to execute an AgentWorkflow. It references
+          an AgentWorkflow and carries generic parameters. The controller orchestrates
+          execution: creates an AgentRun per stage, manages cross-stage handoff via
+          committed files on a shared target branch.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              AgentWorkflowRunSpec defines the desired state of an AgentWorkflowRun.
+              The spec is immutable once created — delete and recreate to change values.
+            properties:
+              env:
+                description: |-
+                  Env is a list of additional environment variables to set across
+                  all stages. Passed through to each AgentRun's Sandbox unchanged.
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: |-
+                        Name of the environment variable.
+                        May consist of any printable ASCII characters except '='.
+                      type: string
+                    value:
+                      description: |-
+                        Variable references $(VAR_NAME) are expanded
+                        using the previously defined environment variables in the container and
+                        any service environment variables. If a variable cannot be resolved,
+                        the reference in the input string will be unchanged. Double $$ are reduced
+                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                        Escaped references will never be expanded, regardless of whether the variable
+                        exists or not.
+                        Defaults to "".
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fieldRef:
+                          description: |-
+                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fileKeyRef:
+                          description: |-
+                            FileKeyRef selects a key of the env file.
+                            Requires the EnvFiles feature gate to be enabled.
+                          properties:
+                            key:
+                              description: |-
+                                The key within the env file. An invalid key will prevent the pod from starting.
+                                The keys defined within a source may consist of any printable ASCII characters except '='.
+                                During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                              type: string
+                            optional:
+                              default: false
+                              description: |-
+                                Specify whether the file or its key must be defined. If the file or key
+                                does not exist, then the env var is not published.
+                                If optional is set to true and the specified key does not exist,
+                                the environment variable will not be set in the Pod's containers.
+
+                                If optional is set to false and the specified key does not exist,
+                                an error will be returned during Pod creation.
+                              type: boolean
+                            path:
+                              description: |-
+                                The path within the volume from which to select the file.
+                                Must be relative and may not contain the '..' path or start with '..'.
+                              type: string
+                            volumeName:
+                              description: The name of the volume mount containing
+                                the env file.
+                              type: string
+                          required:
+                          - key
+                          - path
+                          - volumeName
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        resourceFieldRef:
+                          description: |-
+                            Selects a resource of the container: only resources limits and requests
+                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              envFrom:
+                description: |-
+                  EnvFrom is a list of sources to populate environment variables
+                  across all stages. Passed through to each AgentRun's Sandbox.
+                items:
+                  description: EnvFromSource represents the source of a set of ConfigMaps
+                    or Secrets
+                  properties:
+                    configMapRef:
+                      description: The ConfigMap to select from
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the ConfigMap must be defined
+                          type: boolean
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    prefix:
+                      description: |-
+                        Optional text to prepend to the name of each environment variable.
+                        May consist of any printable ASCII characters except '='.
+                      type: string
+                    secretRef:
+                      description: The Secret to select from
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the Secret must be defined
+                          type: boolean
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  type: object
+                type: array
+              gateway:
+                description: |-
+                  Gateway selects the Gateway (provider/model combination) for all
+                  stages. Individual stages may override this selection in the future.
+                minLength: 1
+                type: string
+              params:
+                description: Params supplies values for Agent parameters across all
+                  stages.
+                items:
+                  description: ParamValue supplies a value for a declared Agent parameter.
+                  properties:
+                    name:
+                      description: Name is the parameter name, matching an Agent param
+                        declaration.
+                      minLength: 1
+                      type: string
+                    value:
+                      description: Value is the parameter value.
+                      type: string
+                  required:
+                  - name
+                  - value
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              workflowRef:
+                description: WorkflowRef is the name of the AgentWorkflow CR to execute.
+                minLength: 1
+                type: string
+            required:
+            - workflowRef
+            type: object
+            x-kubernetes-validations:
+            - message: spec is immutable
+              rule: self == oldSelf
+          status:
+            description: AgentWorkflowRunStatus defines the observed state of an AgentWorkflowRun.
+            properties:
+              completionTime:
+                description: CompletionTime is the time the workflow run finished.
+                format: date-time
+                type: string
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations of the
+                  AgentWorkflowRun's state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              currentStage:
+                description: CurrentStage is the name of the currently executing stage.
+                type: string
+              guide:
+                description: |-
+                  Guide snapshots the AgentWorkflow guide at initialization time, so
+                  mid-run edits do not change it for stages still to run (#87).
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              params:
+                description: |-
+                  Params snapshots the AgentWorkflow's workflow-level parameter
+                  declarations at initialization time, so coercion of the run's
+                  supplied values stays stable across a mid-run workflow edit (#87).
+                items:
+                  description: |-
+                    Param declares a typed parameter that an Agent or AgentWorkflow
+                    accepts. A run (AgentRun / AgentWorkflowRun) supplies values via
+                    ParamValue. Resolved values are delivered to the Sandbox in
+                    /run/konveyor/params.json (see ADR 0009) and may be referenced in
+                    prompt text with $(agent.<name>) / $(workflow.<name>).
+                  properties:
+                    default:
+                      description: Default is the default value if not supplied by
+                        a run.
+                      type: string
+                    description:
+                      description: Description explains the purpose of the parameter.
+                      type: string
+                    name:
+                      description: |-
+                        Name is the parameter name. Referenced in prompt text as
+                        $(agent.<name>) or $(workflow.<name>) and delivered in
+                        params.json under the corresponding section.
+                      minLength: 1
+                      pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                      type: string
+                    required:
+                      description: |-
+                        Required indicates whether the parameter must be supplied.
+                        A parameter with a default is never required.
+                      type: boolean
+                    type:
+                      default: string
+                      description: |-
+                        Type is the parameter type. Controls JSON coercion in
+                        params.json: number as a JSON number, boolean as a JSON boolean,
+                        string as a JSON string.
+                      enum:
+                      - string
+                      - number
+                      - boolean
+                      type: string
+                  required:
+                  - name
+                  type: object
+                  x-kubernetes-validations:
+                  - message: a parameter with a default value cannot be required
+                    rule: '!(has(self.required) && self.required && has(self.default)
+                      && size(self.default) > 0)'
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              phase:
+                default: Pending
+                description: Phase is the current phase of the overall workflow run.
+                enum:
+                - Pending
+                - Running
+                - Succeeded
+                - Failed
+                type: string
+              stages:
+                description: |-
+                  Stages tracks the status of each stage, and snapshots each stage's
+                  definition at initialization time (#87).
+                items:
+                  description: |-
+                    AgentWorkflowRunStageStatus tracks the status of a single stage within
+                    a workflow run.
+                  properties:
+                    agentRef:
+                      description: AgentRef is the snapshotted Agent name for this
+                        stage.
+                      type: string
+                    agentRunName:
+                      description: AgentRunName is the name of the AgentRun CR created
+                        for this stage.
+                      type: string
+                    execution:
+                      description: Execution is the snapshotted stage execution override.
+                      properties:
+                        maxCost:
+                          description: |-
+                            MaxCost is the maximum cumulative cost in USD before wind-down,
+                            as a decimal string (e.g. "10.00"). USD only: the enforcement
+                            threshold must match the currency of reported usage, which is USD
+                            across the supported runtimes. Reported cost may carry an ISO 4217
+                            currency; this threshold does not.
+                          pattern: ^[0-9]+(\.[0-9]{1,2})?$
+                          type: string
+                        maxTurns:
+                          description: |-
+                            MaxTurns is the maximum number of turns before wind-down. The unit
+                            is runtime-defined (e.g. Goose counts turns without user input).
+                          minimum: 1
+                          type: integer
+                        mode:
+                          description: Mode is the supervision policy for tool calls.
+                            Defaults to auto.
+                          enum:
+                          - auto
+                          - approve
+                          type: string
+                      type: object
+                    instructions:
+                      description: Instructions is the snapshotted stage instruction
+                        text.
+                      type: string
+                    name:
+                      description: Name is the stage name, matching a stage in the
+                        AgentWorkflow.
+                      type: string
+                    phase:
+                      description: Phase is the current phase of this stage.
+                      enum:
+                      - Pending
+                      - Running
+                      - Succeeded
+                      - Failed
+                      type: string
+                  required:
+                  - name
+                  - phase
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              startTime:
+                description: StartTime is the time the workflow run started.
+                format: date-time
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/helm/templates/crds/konveyor.io_agentworkflows.yaml
+++ b/helm/templates/crds/konveyor.io_agentworkflows.yaml
@@ -1,0 +1,266 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.21.0
+  name: agentworkflows.konveyor.io
+spec:
+  group: konveyor.io
+  names:
+    kind: AgentWorkflow
+    listKind: AgentWorkflowList
+    plural: agentworkflows
+    shortNames:
+    - aw
+    singular: agentworkflow
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          AgentWorkflow is a reusable workflow combining a high-level guide with an
+          ordered sequence of stages. Each stage references an Agent and carries
+          instructions. An AgentWorkflow is a template — creating one does not
+          execute anything.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AgentWorkflowSpec defines the desired state of an AgentWorkflow.
+            properties:
+              guide:
+                description: |-
+                  Guide is a high-level guide providing ambient context for all stages.
+                  Written as a context file in the workspace so each agent understands
+                  where its work fits in the bigger picture.
+                type: string
+              params:
+                description: |-
+                  Params declares workflow-level typed parameters. An
+                  AgentWorkflowRun supplies values; the controller renders them into
+                  the workflow section of params.json and into $(workflow.<name>)
+                  references in the guide and stage instructions (ADR 0009).
+                items:
+                  description: |-
+                    Param declares a typed parameter that an Agent or AgentWorkflow
+                    accepts. A run (AgentRun / AgentWorkflowRun) supplies values via
+                    ParamValue. Resolved values are delivered to the Sandbox in
+                    /run/konveyor/params.json (see ADR 0009) and may be referenced in
+                    prompt text with $(agent.<name>) / $(workflow.<name>).
+                  properties:
+                    default:
+                      description: Default is the default value if not supplied by
+                        a run.
+                      type: string
+                    description:
+                      description: Description explains the purpose of the parameter.
+                      type: string
+                    name:
+                      description: |-
+                        Name is the parameter name. Referenced in prompt text as
+                        $(agent.<name>) or $(workflow.<name>) and delivered in
+                        params.json under the corresponding section.
+                      minLength: 1
+                      pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                      type: string
+                    required:
+                      description: |-
+                        Required indicates whether the parameter must be supplied.
+                        A parameter with a default is never required.
+                      type: boolean
+                    type:
+                      default: string
+                      description: |-
+                        Type is the parameter type. Controls JSON coercion in
+                        params.json: number as a JSON number, boolean as a JSON boolean,
+                        string as a JSON string.
+                      enum:
+                      - string
+                      - number
+                      - boolean
+                      type: string
+                  required:
+                  - name
+                  type: object
+                  x-kubernetes-validations:
+                  - message: a parameter with a default value cannot be required
+                    rule: '!(has(self.required) && self.required && has(self.default)
+                      && size(self.default) > 0)'
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              stages:
+                description: |-
+                  Stages is the ordered sequence of stages. Each stage references an
+                  Agent and carries instructions. Stages execute sequentially, sharing
+                  the same target branch. Cross-stage continuity comes from committed
+                  handoff files.
+                items:
+                  description: |-
+                    AgentWorkflowStage defines one stage in a workflow.
+                    Each stage references an Agent and carries instructions.
+                  properties:
+                    agentRef:
+                      description: AgentRef is the name of the Agent CR to execute
+                        for this stage.
+                      minLength: 1
+                      type: string
+                    execution:
+                      description: |-
+                        Execution overrides the stage Agent's default supervision mode and
+                        budget limits. The AgentWorkflowRun controller resolves these
+                        (stage override, else Agent default) and stamps the result onto the
+                        stage's AgentRun (ADR 0018). Unset fields fall back to the Agent.
+                      properties:
+                        maxCost:
+                          description: |-
+                            MaxCost is the maximum cumulative cost in USD before wind-down,
+                            as a decimal string (e.g. "10.00"). USD only: the enforcement
+                            threshold must match the currency of reported usage, which is USD
+                            across the supported runtimes. Reported cost may carry an ISO 4217
+                            currency; this threshold does not.
+                          pattern: ^[0-9]+(\.[0-9]{1,2})?$
+                          type: string
+                        maxTurns:
+                          description: |-
+                            MaxTurns is the maximum number of turns before wind-down. The unit
+                            is runtime-defined (e.g. Goose counts turns without user input).
+                          minimum: 1
+                          type: integer
+                        mode:
+                          description: Mode is the supervision policy for tool calls.
+                            Defaults to auto.
+                          enum:
+                          - auto
+                          - approve
+                          type: string
+                      type: object
+                    instructions:
+                      description: |-
+                        Instructions are task-specific instructions for this stage.
+                        Composed with the Agent's prompt at execution time. Supports
+                        $(agent.<name>) / $(workflow.<name>) substitution.
+                      type: string
+                    name:
+                      description: |-
+                        Name is the stage name, unique within the workflow.
+                        Must be a valid Kubernetes label value (lowercase alphanumeric,
+                        hyphens, dots, max 63 chars) since it is used in labels on
+                        child AgentRun resources.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([a-z0-9\-\.]*[a-z0-9])?$
+                      type: string
+                  required:
+                  - agentRef
+                  - name
+                  type: object
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+            required:
+            - stages
+            type: object
+          status:
+            description: AgentWorkflowStatus defines the observed state of an AgentWorkflow.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations of the
+                  AgentWorkflow's state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed
+                  by the controller.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/helm/templates/crds/konveyor.io_gateways.yaml
+++ b/helm/templates/crds/konveyor.io_gateways.yaml
@@ -1,0 +1,214 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.21.0
+  name: gateways.konveyor.io
+spec:
+  group: konveyor.io
+  names:
+    kind: Gateway
+    listKind: GatewayList
+    plural: gateways
+    shortNames:
+    - gw
+    singular: gateway
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.endpoint
+      name: Endpoint
+      type: string
+    - jsonPath: .spec.model.name
+      name: Model
+      type: string
+    - jsonPath: .status.connectionVerified
+      name: Verified
+      type: boolean
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          Gateway is an LLM service endpoint serving exactly one provider/model
+          combination. Each Gateway has credentials and a single model declaration.
+          This mirrors the OpenShell gateway model where one gateway = one model.
+          The controller verifies connectivity on create/update.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: GatewaySpec defines the desired state of a Gateway.
+            properties:
+              credentialRef:
+                description: CredentialRef references a Secret containing the API
+                  credential.
+                properties:
+                  key:
+                    description: |-
+                      Key is the key within the Secret that contains the credential value.
+                      When set, the credential is a single value (e.g. a bearer token) and
+                      is injected into sandbox containers as KONVEYOR_LLM_API_KEY.
+                      When omitted, the credential spans multiple environment variables
+                      (e.g. AWS SigV4: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY,
+                      AWS_REGION) and the whole Secret is exposed to the sandbox container
+                      via envFrom, with the Secret's keys as the variable names.
+                    minLength: 1
+                    type: string
+                  secretName:
+                    description: SecretName is the name of the Secret in the same
+                      namespace.
+                    minLength: 1
+                    type: string
+                required:
+                - secretName
+                type: object
+              endpoint:
+                description: Endpoint is the base URL of the LLM service.
+                minLength: 1
+                type: string
+              model:
+                description: |-
+                  Model is the model served by this gateway. Each Gateway serves
+                  exactly one provider/model combination, mirroring the OpenShell
+                  gateway model where one gateway = one model.
+                properties:
+                  contextWindow:
+                    description: |-
+                      ContextWindow is the maximum context window size in tokens.
+                      Used to validate that an Agent's always-loaded rules fit within budget.
+                    format: int64
+                    minimum: 1
+                    type: integer
+                  name:
+                    description: Name is the model identifier (e.g. "claude-sonnet-4-20250514",
+                      "gpt-4o").
+                    minLength: 1
+                    type: string
+                  tier:
+                    description: |-
+                      Tier is an optional label for the model's capability tier
+                      (e.g. "premium", "efficient").
+                    type: string
+                required:
+                - contextWindow
+                - name
+                type: object
+              provider:
+                description: |-
+                  Provider is the runtime provider identifier (e.g. "anthropic",
+                  "openai", "gcp-vertex-ai"). Injected as KONVEYOR_LLM_PROVIDER
+                  so the harness can map credentials to provider-specific env vars.
+                  This is a pre-OpenShell shim — when OpenShell is integrated,
+                  inference.local eliminates the need for provider-specific
+                  credential mapping and this field is removed.
+                minLength: 1
+                type: string
+            required:
+            - credentialRef
+            - endpoint
+            - model
+            - provider
+            type: object
+          status:
+            description: GatewayStatus defines the observed state of a Gateway.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations of the
+                  Gateway's state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              connectionVerified:
+                description: |-
+                  ConnectionVerified indicates whether the controller has successfully
+                  verified connectivity to the gateway endpoint.
+                type: boolean
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed
+                  by the controller.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/helm/templates/crds/konveyor.io_skillcards.yaml
+++ b/helm/templates/crds/konveyor.io_skillcards.yaml
@@ -1,0 +1,211 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.21.0
+  name: skillcards.konveyor.io
+spec:
+  group: konveyor.io
+  names:
+    kind: SkillCard
+    listKind: SkillCardList
+    plural: skillcards
+    shortNames:
+    - skc
+    singular: skillcard
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.type
+      name: Type
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          SkillCard is an individual agent capability or behavioral constraint.
+          It follows the skillimage.io/v1alpha1 SkillCard format and supports three
+          source types: OCI image ref, git source URL, or inline markdown. All three
+          converge to a resolved OCI image ref in status.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              SkillCardSpec defines the desired state of a SkillCard.
+              Exactly one of Image, Source, or Inline must be set.
+            properties:
+              description:
+                description: Description is a short description of what the skill
+                  does.
+                type: string
+              displayName:
+                description: DisplayName is a human-readable name for the skill.
+                type: string
+              image:
+                description: Image is an OCI image reference for a pre-built skill
+                  artifact.
+                type: string
+              inline:
+                description: |-
+                  Inline is raw markdown content for the skill, delivered as a ConfigMap.
+                  A ConfigMap key cannot hold a path separator, so an inline skill is a
+                  single SKILL.md and cannot ship supporting files.
+                type: string
+              ref:
+                description: |-
+                  Ref is the branch, tag or commit to check out from Source. Empty
+                  clones the default branch, which makes the run unreproducible, and the
+                  loader warns when it is unset.
+                  Only meaningful with Source.
+                type: string
+              source:
+                description: |-
+                  Source is a git URL. The skill loader clones it at pod start; nothing
+                  is built.
+                type: string
+              subPath:
+                description: |-
+                  SubPath selects one skill from a source that holds several, naming its
+                  directory within the image or repository. A SkillCard is always one
+                  skill, so a source holding several without a SubPath is an error.
+                  Only meaningful with Image or Source.
+                type: string
+              tags:
+                description: Tags are labels for categorization and discovery.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              type:
+                default: skill
+                description: |-
+                  Type is this skill's load policy. Defaults to "skill".
+
+                  It lives here rather than in SKILL.md: the Agent Skills spec's field set
+                  is closed, so declaring it in content would break the format (ADR 0015).
+                enum:
+                - skill
+                - rule
+                type: string
+              version:
+                description: Version is the semantic version of the skill.
+                type: string
+            type: object
+            x-kubernetes-validations:
+            - message: exactly one of image, source, or inline must be set
+              rule: '(has(self.image) ? 1 : 0) + (has(self.source) ? 1 : 0) + (has(self.inline)
+                ? 1 : 0) == 1'
+          status:
+            description: SkillCardStatus defines the observed state of a SkillCard.
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the SkillCard's state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              deliveryMode:
+                description: |-
+                  DeliveryMode is how this skill reaches the pod, so that "not resolved
+                  yet" is distinguishable from "resolved, just not to an image".
+                enum:
+                - image
+                - inline
+                - source
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              resolvedImage:
+                description: |-
+                  ResolvedImage is the OCI image reference for the resolved skill artifact.
+                  Only an image source resolves to one; for inline and git it stays empty
+                  because there is no image, so read DeliveryMode rather than inferring
+                  from this being unset.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/helm/templates/crds/konveyor.io_skillcollections.yaml
+++ b/helm/templates/crds/konveyor.io_skillcollections.yaml
@@ -1,0 +1,226 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.21.0
+  name: skillcollections.konveyor.io
+spec:
+  group: konveyor.io
+  names:
+    kind: SkillCollection
+    listKind: SkillCollectionList
+    plural: skillcollections
+    shortNames:
+    - scol
+    singular: skillcollection
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          SkillCollection is a group of skills, following the skillimage.io/v1alpha1
+          SkillCollection format. Each entry references a skill by OCI image ref,
+          git source URL, or SkillCard CR name. The controller creates SkillCard CRs
+          for git-sourced entries and reports readiness when all children are resolved.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              SkillCollectionSpec defines the desired state of a SkillCollection.
+              Set either Image or Skills.
+            properties:
+              image:
+                description: |-
+                  Image is an OCI image holding one or more skills. The controller
+                  enumerates it with a short-lived Job and creates a SkillCard per skill
+                  it finds, owned by this collection, so a user points at a source once
+                  rather than writing a card per skill.
+                type: string
+              skills:
+                description: |-
+                  Skills is an explicit list, for grouping skills that already exist.
+
+                  MinItems, because the rule above is satisfied by a list that is present
+                  and empty: without it `skills: []` is admitted and the collection is
+                  simply never Ready, where the field used to be rejected outright.
+                items:
+                  description: |-
+                    SkillCollectionSkillRef references a skill by SkillCard CR name,
+                    OCI image ref, or git source URL. Exactly one of SkillCardRef,
+                    Image, or Source must be set.
+                  properties:
+                    image:
+                      description: Image is an OCI image reference for a pre-built
+                        skill artifact.
+                      type: string
+                    name:
+                      description: Name is the local name for this skill within the
+                        collection.
+                      minLength: 1
+                      type: string
+                    ref:
+                      description: |-
+                        Ref is the branch, tag or commit to check out from Source. Empty
+                        clones the default branch, leaving the run unreproducible.
+                        Only meaningful with Source.
+                      type: string
+                    skillCardRef:
+                      description: SkillCardRef is the name of a SkillCard CR in the
+                        same namespace.
+                      type: string
+                    source:
+                      description: Source is a git URL. The skill loader clones it
+                        at pod start.
+                      type: string
+                    subPath:
+                      description: |-
+                        SubPath selects one skill from a source holding several, naming its
+                        directory within the image or repository.
+                        Only meaningful with Image or Source.
+                      type: string
+                    type:
+                      description: |-
+                        Type is the load policy for this entry's skill. Defaults to "skill".
+                        Ignored when SkillCardRef is set, since the card carries its own.
+                      enum:
+                      - skill
+                      - rule
+                      type: string
+                  required:
+                  - name
+                  type: object
+                  x-kubernetes-validations:
+                  - message: exactly one of skillCardRef, image, or source must be
+                      set
+                    rule: '(has(self.skillCardRef) ? 1 : 0) + (has(self.image) ? 1
+                      : 0) + (has(self.source) ? 1 : 0) == 1'
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              type:
+                description: |-
+                  Type is the load policy applied to every skill enumerated from Image.
+                  Defaults to "skill". Per-skill policy within one image is not yet
+                  expressible; see ADR 0015.
+                enum:
+                - skill
+                - rule
+                type: string
+              version:
+                description: Version is the semantic version of the collection.
+                type: string
+            type: object
+            x-kubernetes-validations:
+            - message: set either image or skills, not both
+              rule: has(self.image) != has(self.skills)
+          status:
+            description: SkillCollectionStatus defines the observed state of a SkillCollection.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations of the
+                  SkillCollection's state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              resolvedSkills:
+                description: |-
+                  ResolvedSkills names the SkillCards this collection owns, whether
+                  enumerated from Image or listed explicitly.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -67,6 +67,20 @@ spec:
           value: {{ .Values.images.kai }}
         - name: RELATED_IMAGE_LIGHTSPEED_STACK
           value: {{ .Values.images.lightspeed_stack }}
+        - name: RELATED_IMAGE_AGENTIC_CONTROLLER
+          value: {{ .Values.images.agentic_controller }}
+        - name: RELATED_IMAGE_AGENT_BASE
+          value: {{ .Values.images.agent_base }}
+        - name: RELATED_IMAGE_AGENT_GO
+          value: {{ .Values.images.agent_go }}
+        - name: RELATED_IMAGE_AGENT_JAVA
+          value: {{ .Values.images.agent_java }}
+        - name: RELATED_IMAGE_AGENT_CSHARP
+          value: {{ .Values.images.agent_csharp }}
+        - name: RELATED_IMAGE_AGENT_NODEJS
+          value: {{ .Values.images.agent_nodejs }}
+        - name: RELATED_IMAGE_AGENT_SKILLS
+          value: {{ .Values.images.agent_skills }}
         name: tackle-operator
         image: {{ .Values.images.operator }}
         imagePullPolicy: Always

--- a/helm/templates/olm/konveyor-operator.clusterserviceversion.yaml
+++ b/helm/templates/olm/konveyor-operator.clusterserviceversion.yaml
@@ -189,7 +189,7 @@ spec:
   - email: konveyor-dev@googlegroups.com
     name: Konveyor Community
   maturity: alpha
-  minKubeVersion: 1.22.0
+  minKubeVersion: 1.25.0
   provider:
     name: Konveyor
     url: https://www.konveyor.io

--- a/helm/templates/olm/konveyor-operator.clusterserviceversion.yaml
+++ b/helm/templates/olm/konveyor-operator.clusterserviceversion.yaml
@@ -48,6 +48,43 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
+    - description: Agent is a capability definition declaring what is available for
+        execution.
+      displayName: Agent
+      kind: Agent
+      name: agents.konveyor.io
+      version: v1alpha1
+    - description: AgentRun is a request to execute a single Agent with specific selections.
+      displayName: Agent Run
+      kind: AgentRun
+      name: agentruns.konveyor.io
+      version: v1alpha1
+    - description: AgentWorkflow is a reusable workflow combining a high-level guide
+        with an ordered sequence of stages.
+      displayName: Agent Workflow
+      kind: AgentWorkflow
+      name: agentworkflows.konveyor.io
+      version: v1alpha1
+    - description: AgentWorkflowRun is a request to execute an AgentWorkflow.
+      displayName: Agent Workflow Run
+      kind: AgentWorkflowRun
+      name: agentworkflowruns.konveyor.io
+      version: v1alpha1
+    - description: Gateway is an LLM service endpoint serving exactly one provider/model.
+      displayName: Gateway
+      kind: Gateway
+      name: gateways.konveyor.io
+      version: v1alpha1
+    - description: SkillCard is an individual agent capability or behavioral constraint.
+      displayName: Skill Card
+      kind: SkillCard
+      name: skillcards.konveyor.io
+      version: v1alpha1
+    - description: SkillCollection is a group of skills.
+      displayName: Skill Collection
+      kind: SkillCollection
+      name: skillcollections.konveyor.io
+      version: v1alpha1
     - description: Tackle Addon
       displayName: Addon
       kind: Addon

--- a/helm/templates/rbac/agentic_cluster_role.yaml
+++ b/helm/templates/rbac/agentic_cluster_role.yaml
@@ -1,0 +1,133 @@
+---
+# Synced from konveyor/agentic-controller config/rbac/role.yaml (manager-role).
+# metadata.name is renamed to avoid colliding with the operator's own
+# manager-role. Rules are otherwise verbatim; do not hand-edit -- update by
+# re-syncing from agentic-controller.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: agentic-controller-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - agents.x-k8s.io
+  resources:
+  - sandboxes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - konveyor.io
+  resources:
+  - agentruns
+  - agents
+  - agentworkflowruns
+  - agentworkflows
+  - gateways
+  - skillcards
+  - skillcollections
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - konveyor.io
+  resources:
+  - agentruns/finalizers
+  - agents/finalizers
+  - agentworkflowruns/finalizers
+  - agentworkflows/finalizers
+  - gateways/finalizers
+  - skillcards/finalizers
+  - skillcollections/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - konveyor.io
+  resources:
+  - agentruns/status
+  - agents/status
+  - agentworkflowruns/status
+  - agentworkflows/status
+  - gateways/status
+  - skillcards/status
+  - skillcollections/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/helm/templates/rbac/agentic_cluster_role_binding.yaml
+++ b/helm/templates/rbac/agentic_cluster_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: agentic-controller-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: agentic-controller-manager-role
+subjects:
+- kind: ServiceAccount
+  name: agentic-controller
+  namespace: {{ .Release.Namespace }}

--- a/helm/templates/rbac/agentic_leader_election_role.yaml
+++ b/helm/templates/rbac/agentic_leader_election_role.yaml
@@ -1,0 +1,40 @@
+---
+# Synced from konveyor/agentic-controller config/rbac/leader_election_role.yaml
+# (leader-election-role), renamed to avoid collisions. Permits the controller's
+# leader election. Do not hand-edit -- update by re-syncing.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: agentic-controller-leader-election-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/helm/templates/rbac/agentic_leader_election_role_binding.yaml
+++ b/helm/templates/rbac/agentic_leader_election_role_binding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: agentic-controller-leader-election-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: agentic-controller-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: agentic-controller

--- a/helm/templates/rbac/agentic_service_account.yaml
+++ b/helm/templates/rbac/agentic_service_account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: agentic-controller

--- a/helm/templates/rbac/cluster_role.yaml
+++ b/helm/templates/rbac/cluster_role.yaml
@@ -44,4 +44,15 @@ rules:
   - list
   - watch
   - delete
+# Read-only detection of the Agent Sandbox CRD for the agentic controller
+# pre-flight (roles/tackle/tasks/agentic.yml). This is the operator's own
+# detection permission, distinct from the agentic operand RBAC.
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
 #+kubebuilder:scaffold:rules

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -28,3 +28,10 @@ images:
   kantra: quay.io/konveyor/kantra:latest
   kai: quay.io/konveyor/kai-solution-server:latest
   lightspeed_stack: quay.io/lightspeed-core/lightspeed-stack:latest
+  agentic_controller: quay.io/konveyor/agentic-controller:latest
+  agent_base: quay.io/konveyor/agent-base:latest
+  agent_go: quay.io/konveyor/agent-go:latest
+  agent_java: quay.io/konveyor/agent-java:latest
+  agent_csharp: quay.io/konveyor/agent-csharp:latest
+  agent_nodejs: quay.io/konveyor/agent-nodejs:latest
+  agent_skills: quay.io/konveyor/skills:latest

--- a/roles/tackle/defaults/main.yml
+++ b/roles/tackle/defaults/main.yml
@@ -305,3 +305,20 @@ kai_llm_proxy_api_key_env_map:
   anthropic: "ANTHROPIC_API_KEY"
 
 kai_llm_proxy_api_key_env: "{{ kai_llm_proxy_api_key_env_map[kai_llm_provider] | default(kai_llm_provider | upper + '_API_KEY') if kai_llm_provider else 'OPENAI_API_KEY' }}"
+
+# Agentic controller variables
+# Opt-in operand (default off). Requires the Agent Sandbox CRD
+# (sandboxes.agents.x-k8s.io) to be installed in the cluster; when absent the
+# controller is not deployed and AgenticControllerReady is posted as False.
+agentic_enabled: false
+agentic_component_name: "agentic-controller"
+agentic_fqin: "{{ lookup('env', 'RELATED_IMAGE_AGENTIC_CONTROLLER') }}"
+# agent runtime + skills images are opaque CR data (Agent.spec.image /
+# SkillCard.spec.image), not consumed by the controller Deployment. Declared
+# only so they land in the CSV relatedImages for disconnected mirroring.
+agentic_agent_base_fqin: "{{ lookup('env', 'RELATED_IMAGE_AGENT_BASE') }}"
+agentic_agent_go_fqin: "{{ lookup('env', 'RELATED_IMAGE_AGENT_GO') }}"
+agentic_agent_java_fqin: "{{ lookup('env', 'RELATED_IMAGE_AGENT_JAVA') }}"
+agentic_agent_csharp_fqin: "{{ lookup('env', 'RELATED_IMAGE_AGENT_CSHARP') }}"
+agentic_agent_nodejs_fqin: "{{ lookup('env', 'RELATED_IMAGE_AGENT_NODEJS') }}"
+agentic_skills_fqin: "{{ lookup('env', 'RELATED_IMAGE_AGENT_SKILLS') }}"

--- a/roles/tackle/defaults/main.yml
+++ b/roles/tackle/defaults/main.yml
@@ -311,6 +311,12 @@ kai_llm_proxy_api_key_env: "{{ kai_llm_proxy_api_key_env_map[kai_llm_provider] |
 # (sandboxes.agents.x-k8s.io) to be installed in the cluster; when absent the
 # controller is not deployed and AgenticControllerReady is posted as False.
 agentic_enabled: false
+# Surfaces the agentic console in the UI (AGENTIC_ENABLED). Follows
+# agentic_enabled so a single switch lights up the controller and the console.
+# AGENTIC_STEER_ENABLED is a separate, riskier opt-in (inject instructions into
+# and stop a live run) that stays off by default even when the console is on,
+# mirroring the UI's own default.
+agentic_steer_enabled: false
 agentic_component_name: "agentic-controller"
 agentic_fqin: "{{ lookup('env', 'RELATED_IMAGE_AGENTIC_CONTROLLER') }}"
 # agent runtime + skills images are opaque CR data (Agent.spec.image /

--- a/roles/tackle/tasks/agentic-status.yml
+++ b/roles/tackle/tasks/agentic-status.yml
@@ -2,49 +2,53 @@
 # Updates the AgenticControllerReady condition on the Tackle CR.
 # Only runs when invoked through the operator (ansible_operator_meta is defined).
 #
-# When the feature is disabled we post nothing: a feature the admin never
-# enabled should not surface a (red) condition. When enabled there are two
-# outcomes:
-#   - Agent Sandbox CRD missing  -> False / AgentSandboxMissing
-#   - Agent Sandbox CRD present   -> readiness of the controller Deployment
+# Three outcomes:
+#   - feature disabled             -> False / Disabled
+#   - enabled, Sandbox CRD absent  -> False / AgentSandboxMissing
+#   - enabled, Sandbox CRD present -> readiness of the controller Deployment
+#
+# The condition is posted in all cases (including disabled) so it never goes
+# stale: disabling the feature removes the Deployment and must flip the
+# condition away from a previously-posted True.
 
-- name: Manage AgenticControllerReady condition
-  when: agentic_enabled | bool
-  block:
-    - name: Check agentic controller deployment status
-      k8s_info:
-        api_version: apps/v1
-        kind: Deployment
-        name: "{{ agentic_component_name }}"
-        namespace: "{{ app_namespace }}"
-      register: agentic_deployment
-      when: agentic_sandbox_crd_present | bool
+- name: Check agentic controller deployment status
+  k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    name: "{{ agentic_component_name }}"
+    namespace: "{{ app_namespace }}"
+  register: agentic_deployment
+  when: agentic_enabled | bool and agentic_sandbox_crd_present | bool
 
-    - name: Set agentic controller ready status
-      set_fact:
-        agentic_deployment_ready: "{{ agentic_sandbox_crd_present | bool and
-                                      (agentic_deployment.resources | default([]) | length) > 0 and
-                                      (agentic_deployment.resources[0].status.readyReplicas | default(0)) > 0 and
-                                      (agentic_deployment.resources[0].status.readyReplicas | default(0)) == (agentic_deployment.resources[0].status.replicas | default(1)) and
-                                      (agentic_deployment.resources[0].status.updatedReplicas | default(0)) == (agentic_deployment.resources[0].status.replicas | default(1)) }}"
+- name: Set agentic controller ready status
+  set_fact:
+    agentic_deployment_ready: "{{ agentic_enabled | bool and agentic_sandbox_crd_present | bool and
+                                  (agentic_deployment.resources | default([]) | length) > 0 and
+                                  (agentic_deployment.resources[0].status.readyReplicas | default(0)) > 0 and
+                                  (agentic_deployment.resources[0].status.readyReplicas | default(0)) == (agentic_deployment.resources[0].status.replicas | default(1)) and
+                                  (agentic_deployment.resources[0].status.updatedReplicas | default(0)) == (agentic_deployment.resources[0].status.replicas | default(1)) }}"
 
-    - name: Update AgenticControllerReady condition
-      operator_sdk.util.k8s_status:
-        api_version: tackle.konveyor.io/v1alpha1
-        kind: Tackle
-        name: "{{ ansible_operator_meta.name }}"
-        namespace: "{{ ansible_operator_meta.namespace }}"
-        conditions:
-          - type: AgenticControllerReady
-            status: >-
-              {{ 'False' if not agentic_sandbox_crd_present | bool else
-                 ('True' if agentic_deployment_ready else 'False') }}
-            reason: >-
-              {{ 'AgentSandboxMissing' if not agentic_sandbox_crd_present | bool else
-                 ('DeploymentReady' if agentic_deployment_ready else 'DeploymentNotReady') }}
-            message: >-
-              {{ 'The Agent Sandbox CRD (sandboxes.agents.x-k8s.io) is not installed. Install Agent Sandbox before enabling the agentic controller.'
-                 if not agentic_sandbox_crd_present | bool else
-                 ('Agentic controller is running and ready' if agentic_deployment_ready else
-                  'Agentic controller deployment is not ready. Check pod logs for details.') }}
-            lastTransitionTime: "{{ now(fmt='%Y-%m-%dT%H:%M:%SZ') }}"
+- name: Update AgenticControllerReady condition
+  operator_sdk.util.k8s_status:
+    api_version: tackle.konveyor.io/v1alpha1
+    kind: Tackle
+    name: "{{ ansible_operator_meta.name }}"
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    conditions:
+      - type: AgenticControllerReady
+        status: >-
+          {{ 'False' if not agentic_enabled | bool else
+             ('False' if not agentic_sandbox_crd_present | bool else
+              ('True' if agentic_deployment_ready else 'False')) }}
+        reason: >-
+          {{ 'Disabled' if not agentic_enabled | bool else
+             ('AgentSandboxMissing' if not agentic_sandbox_crd_present | bool else
+              ('DeploymentReady' if agentic_deployment_ready else 'DeploymentNotReady')) }}
+        message: >-
+          {{ 'The agentic controller is disabled (spec.agentic_enabled is false).'
+             if not agentic_enabled | bool else
+             ('The Agent Sandbox CRD (sandboxes.agents.x-k8s.io) is not installed. Install Agent Sandbox before enabling the agentic controller.'
+              if not agentic_sandbox_crd_present | bool else
+              ('Agentic controller is running and ready' if agentic_deployment_ready else
+               'Agentic controller deployment is not ready. Check pod logs for details.')) }}
+        lastTransitionTime: "{{ now(fmt='%Y-%m-%dT%H:%M:%SZ') }}"

--- a/roles/tackle/tasks/agentic-status.yml
+++ b/roles/tackle/tasks/agentic-status.yml
@@ -1,0 +1,50 @@
+---
+# Updates the AgenticControllerReady condition on the Tackle CR.
+# Only runs when invoked through the operator (ansible_operator_meta is defined).
+#
+# When the feature is disabled we post nothing: a feature the admin never
+# enabled should not surface a (red) condition. When enabled there are two
+# outcomes:
+#   - Agent Sandbox CRD missing  -> False / AgentSandboxMissing
+#   - Agent Sandbox CRD present   -> readiness of the controller Deployment
+
+- name: Manage AgenticControllerReady condition
+  when: agentic_enabled | bool
+  block:
+    - name: Check agentic controller deployment status
+      k8s_info:
+        api_version: apps/v1
+        kind: Deployment
+        name: "{{ agentic_component_name }}"
+        namespace: "{{ app_namespace }}"
+      register: agentic_deployment
+      when: agentic_sandbox_crd_present | bool
+
+    - name: Set agentic controller ready status
+      set_fact:
+        agentic_deployment_ready: "{{ agentic_sandbox_crd_present | bool and
+                                      (agentic_deployment.resources | default([]) | length) > 0 and
+                                      (agentic_deployment.resources[0].status.readyReplicas | default(0)) > 0 and
+                                      (agentic_deployment.resources[0].status.readyReplicas | default(0)) == (agentic_deployment.resources[0].status.replicas | default(1)) and
+                                      (agentic_deployment.resources[0].status.updatedReplicas | default(0)) == (agentic_deployment.resources[0].status.replicas | default(1)) }}"
+
+    - name: Update AgenticControllerReady condition
+      operator_sdk.util.k8s_status:
+        api_version: tackle.konveyor.io/v1alpha1
+        kind: Tackle
+        name: "{{ ansible_operator_meta.name }}"
+        namespace: "{{ ansible_operator_meta.namespace }}"
+        conditions:
+          - type: AgenticControllerReady
+            status: >-
+              {{ 'False' if not agentic_sandbox_crd_present | bool else
+                 ('True' if agentic_deployment_ready else 'False') }}
+            reason: >-
+              {{ 'AgentSandboxMissing' if not agentic_sandbox_crd_present | bool else
+                 ('DeploymentReady' if agentic_deployment_ready else 'DeploymentNotReady') }}
+            message: >-
+              {{ 'The Agent Sandbox CRD (sandboxes.agents.x-k8s.io) is not installed. Install Agent Sandbox before enabling the agentic controller.'
+                 if not agentic_sandbox_crd_present | bool else
+                 ('Agentic controller is running and ready' if agentic_deployment_ready else
+                  'Agentic controller deployment is not ready. Check pod logs for details.') }}
+            lastTransitionTime: "{{ now(fmt='%Y-%m-%dT%H:%M:%SZ') }}"

--- a/roles/tackle/tasks/agentic.yml
+++ b/roles/tackle/tasks/agentic.yml
@@ -1,0 +1,35 @@
+---
+# Agentic controller operand tasks.
+#
+# The agentic controller requires the Agent Sandbox CRD
+# (sandboxes.agents.x-k8s.io) to be present in the cluster: it adds the type to
+# its scheme and Owns() Sandbox objects, so it crash-loops at startup when the
+# CRD is absent. Agent Sandbox is therefore a deployment prerequisite installed
+# separately (not an operator-managed operand). We pre-flight for the CRD and
+# only deploy the controller when it is present.
+
+- name: Check for the Agent Sandbox CRD
+  k8s_info:
+    api_version: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    name: sandboxes.agents.x-k8s.io
+  register: agentic_sandbox_crd
+  when: agentic_enabled | bool
+
+- name: Determine Agent Sandbox CRD presence
+  set_fact:
+    agentic_sandbox_crd_present: "{{ (agentic_sandbox_crd.resources | default([]) | length) > 0 }}"
+
+- name: Set agentic controller deployment state
+  set_fact:
+    agentic_state: "{{ 'present' if (agentic_enabled | bool and agentic_sandbox_crd_present | bool) else 'absent' }}"
+
+- name: Create agentic controller Deployment
+  k8s:
+    state: "{{ agentic_state }}"
+    template: agentic/deployment.yaml.j2
+    merge_type: merge
+
+- name: Update agentic controller status conditions
+  when: ansible_operator_meta is defined
+  import_tasks: agentic-status.yml

--- a/roles/tackle/tasks/main.yml
+++ b/roles/tackle/tasks/main.yml
@@ -498,3 +498,6 @@
 
 - name: Run kai tasks
   import_tasks: kai.yml
+
+- name: Run agentic controller tasks
+  import_tasks: agentic.yml

--- a/roles/tackle/templates/agentic/deployment.yaml.j2
+++ b/roles/tackle/templates/agentic/deployment.yaml.j2
@@ -1,0 +1,77 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ agentic_component_name }}
+  namespace: "{{ app_namespace }}"
+  labels:
+    app.kubernetes.io/name: {{ agentic_component_name }}
+    app.kubernetes.io/component: {{ agentic_component_name }}
+    app.kubernetes.io/part-of: {{ app_name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ agentic_component_name }}
+      app.kubernetes.io/component: {{ agentic_component_name }}
+      app.kubernetes.io/part-of: {{ app_name }}
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        app.kubernetes.io/name: {{ agentic_component_name }}
+        app.kubernetes.io/component: {{ agentic_component_name }}
+        app.kubernetes.io/part-of: {{ app_name }}
+    spec:
+      serviceAccountName: {{ agentic_component_name }}
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: manager
+          image: "{{ agentic_fqin }}"
+          command:
+            - /manager
+          args:
+            - --leader-elect
+            - --health-probe-bind-address=:8081
+            - --metrics-bind-address=0
+          env:
+            # The skill loader and the enumeration Job run this same image. The
+            # controller cannot read its own image (it deliberately lacks
+            # `pods get`), so SKILL_LOADER_IMAGE must be set explicitly and kept
+            # equal to the image above (kustomize kept them in sync upstream).
+            - name: SKILL_LOADER_IMAGE
+              value: "{{ agentic_fqin }}"
+          ports:
+            - containerPort: 8081
+              name: health
+              protocol: TCP
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "ALL"
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: 500m
+              memory: 128Mi
+            requests:
+              cpu: 10m
+              memory: 64Mi
+      terminationGracePeriodSeconds: 10

--- a/roles/tackle/templates/deployment-ui.yml.j2
+++ b/roles/tackle/templates/deployment-ui.yml.j2
@@ -46,6 +46,10 @@ spec:
               value: "{{ hub_url }}"
             - name: AUTH_REQUIRED
               value: "{{ feature_auth_required | string | lower }}"
+            - name: AGENTIC_ENABLED
+              value: "{{ agentic_enabled | string | lower }}"
+            - name: AGENTIC_STEER_ENABLED
+              value: "{{ agentic_steer_enabled | string | lower }}"
             - name: OIDC_ISSUER
               value: "{{ hub_url }}/oidc"
             - name: OIDC_CLIENT_ID


### PR DESCRIPTION
## Summary

Adds the **agentic controller** as an opt-in operand, mirroring the `kai` solution-server pattern. Fixes konveyor/operator#591.

Gated behind `spec.agentic_enabled` (default `false`); the Tackle CRD is schemaless so no CRD schema change is required. When disabled the feature is completely inert.

## What's included

**Operand role (`roles/tackle/`)**
- `agentic_enabled` + image fqin defaults.
- `agentic.yml`: pre-flights for the Agent Sandbox CRD (`sandboxes.agents.x-k8s.io`) and only deploys the controller when present (it crash-loops without it). Creates the Deployment only.
- `agentic-status.yml`: posts `AgenticControllerReady` — nothing when disabled, `False/AgentSandboxMissing` when the CRD is absent, deployment readiness otherwise.
- `agentic/deployment.yaml.j2`: de-kustomized controller manager (`SKILL_LOADER_IMAGE == image`, metrics disabled).

**Helm (unconditional, matches existing operand convention)**
- 7 `konveyor.io` CRDs vendored under `helm/templates/crds/`.
- Agentic RBAC under `helm/templates/rbac/` (SA + ClusterRole + leader-election Role + bindings, named `agentic-controller-*` to avoid colliding with the operator's `manager-role`), bound to the agentic SA — the operator's own role is **not** widened with operand powers.
- Operator role gains **read-only** `customresourcedefinitions` access for the pre-flight only.
- `values.yaml` + `RELATED_IMAGE_*` env for the controller and agent/skills images (disconnected mirroring).

**OLM/bundle**
- 7 CRDs added to CSV `owned`; agentic SA added to `--extra-service-accounts` so its ClusterRole lands in CSV `clusterPermissions`; `relatedImages` populated; `bundle/` regenerated.

## Notes for reviewers

- **New CSV cluster permissions:** the agentic RBAC/CSV `clusterPermissions` ship unconditionally (the `agentic_enabled` flag is a runtime Tackle-CR value, not a helm value). This matches the existing unconditional operand-CRD/RBAC convention; the SA is dormant when the feature is off.
- **Agent Sandbox is a prerequisite**, installed separately (not bundled). The controller is not deployed if its CRD is absent.
- Metrics are disabled in this PR (follow-up: konveyor/operator#595).

## Follow-ups
- konveyor/operator#595 — enable agentic metrics.
- konveyor/agentic-controller#190 — push-sync CRDs/RBAC to this repo.
- konveyor/agentic-controller#191 — research + wire up the full operator-install deploy-and-Ready e2e.

## Verification
- `helm template` renders cleanly (CRDs, RBAC, RELATED_IMAGE env, CSV).
- `operator-sdk bundle validate` passes; `make bundle` idempotent except `createdAt` (ignored by `bundle-sync-check`).
- `ansible-lint` passes.

```release-note
Add the agentic controller as an opt-in operand, enabled via `spec.agentic_enabled`. Requires the Agent Sandbox CRD to be installed in the cluster.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in agentic capabilities for running agents and workflows.
  * Introduced resources for agents, runs, workflows, gateways, skill cards, and skill collections.
  * Added configuration for agent runtimes, skills, and disconnected image mirroring.
  * Added deployment readiness status and prerequisite checks.
  * Added support for configuring agent images and runtime components.
  * Added optional Agent Sandbox installation and improved installer compatibility across OLM environments.
* **Bug Fixes**
  * Prevents deployment when the required Agent Sandbox capability is unavailable.
  * Reports clear status conditions when agentic components are disabled or not ready.
* **Documentation**
  * Updated prerequisites to Kubernetes 1.25+ and OpenShift 4.12+.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->