### PR TITLE
:sparkles: Add hub_agent_namespace to decouple the Hub's agent namespace

### DIFF
--- a/roles/tackle/defaults/main.yml
+++ b/roles/tackle/defaults/main.yml
@@ -4,6 +4,10 @@
 # App defaults
 app_name: "{{ lookup('env', 'APP_NAME') or 'tackle' }}"
 app_namespace: "{{ lookup('env', 'WATCH_NAMESPACE') or 'konveyor-tackle' }}"
+# Namespace the Hub watches for agentic resources (Agents, Gateways, AgentRuns,
+# AgentWorkflows). Defaults to the Hub's own namespace to preserve existing
+# behaviour; override to point the Hub at a separate agent namespace.
+hub_agent_namespace: "{{ app_namespace }}"
 app_profile: "{{ lookup('env', 'PROFILE') }}"
 app_version: "{{ lookup('env', 'VERSION') }}"
 

--- a/roles/tackle/templates/deployment-hub.yml.j2
+++ b/roles/tackle/templates/deployment-hub.yml.j2
@@ -37,10 +37,7 @@ spec:
           imagePullPolicy: "{{ image_pull_policy }}"
           env:
             - name: NAMESPACE
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: metadata.namespace
+              value: "{{ hub_agent_namespace }}"
             - name: APP_NAME
               value: "{{ app_name }}"
             - name: PROFILE


### PR DESCRIPTION
## Problem

The Hub decides which namespace holds agentic resources (`Agents`, `Gateways`,
`AgentRuns`, `AgentWorkflows`) from its `NAMESPACE` env. The operator hardcodes
that env to the Hub pod's own namespace:

```yaml
# roles/tackle/templates/deployment-hub.yml.j2
- name: NAMESPACE
  valueFrom:
    fieldRef:
      fieldPath: metadata.namespace
```

Deployments that keep agentic resources in a namespace **separate** from the Hub
cannot express that through the operator. The Hub lists in its own namespace,
finds nothing (and often lacks RBAC there), and `/agentic/*` returns 500. The
only workaround today is to hand-edit the Hub Deployment, which the operator
reconciles away on the next pass.

## Change

Add a `hub_agent_namespace` variable and template it into the Hub's `NAMESPACE`
env.

- Defaults to `app_namespace`, so existing single-namespace installs are
  **unchanged**.
- Operators that split the Hub and its agents can now set
  `spec.hub_agent_namespace` on the Tackle CR to point the Hub at a dedicated
  agent namespace (RBAC for that namespace provisioned separately).

```yaml
spec:
  hub_agent_namespace: my-agents
```

Two files, opt-in only. Happy to adjust the variable name or add it to a values
doc if preferred.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration to specify which namespace the Hub monitors for agent-related resources.
  * Defaults to the existing application namespace, while allowing monitoring from a separate namespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->