### PR TITLE
:bug: Fix install-konveyor.sh aborting bundle deploy before OLM is ready

### DIFF
--- a/hack/install-konveyor.sh
+++ b/hack/install-konveyor.sh
@@ -203,9 +203,15 @@ start_agent_sandbox() {
 # Discover the namespace where OLM is running. Self-installed OLM (kind/minikube)
 # uses 'olm', while OpenShift ships it in 'openshift-operator-lifecycle-manager'.
 # The packageserver CSV lives in the OLM namespace in both cases.
+#
+# This is a best-effort probe: before OLM is installed the
+# clusterserviceversions CRD does not exist yet, so kubectl exits non-zero.
+# The trailing '|| true' keeps that non-zero from tripping 'set -e' (and
+# 'set -o pipefail') when the result is assigned in a bare command
+# substitution by callers, e.g. `olm_namespace=$(get_olm_namespace)`.
 get_olm_namespace() {
   kubectl get clusterserviceversions.operators.coreos.com --all-namespaces 2>/dev/null \
-    | awk '/packageserver/ {print $1; exit}'
+    | awk '/packageserver/ {print $1; exit}' || true
 }
 
 start_bundle() {


### PR DESCRIPTION
## Problem

The nightly `main-nightly / e2e-api-integration-tests` job started failing in the `Setup Konveyor` step with:

```
Error: Global timeout reached while waiting for Tackle CRD
KONVEYOR INSTALLATION FAILED
Error: One or more background processes failed
make: *** [Makefile:279: install-konveyor] Error 1
```

The `konveyor-tackle` namespace ends up empty — no CatalogSource, Subscription, CSV, or `tackles` CRD — i.e. the operator bundle is never deployed. In the log, `start_bundle` prints its two banner lines and then produces **no further output** for the full 10-minute global timeout.

## Root cause

`get_olm_namespace()` probes for the OLM namespace by listing `clusterserviceversions`. Before OLM is installed that CRD does not exist yet, so `kubectl` exits non-zero and, with `set -o pipefail`, the whole pipeline fails.

Callers assign the result via a **bare command substitution** (`olm_namespace=$(get_olm_namespace)`), which — unlike an `if` condition — is **not** exempt from `set -e`. The phases run as `( set +E; start_bundle ) &`, but `set +E` disables only the ERR trap, **not** errexit. So on the first loop iteration (before OLM is up) the `start_bundle` subshell exits immediately → the bundle is never deployed → the Tackle CRD never appears → `start_tackle` loops until the global timeout.

This regressed in #596, which replaced the errexit-safe `if kubectl get namespace olm` check with this helper.

## Fix

Make the probe best-effort with a trailing `|| true`, so a non-zero exit during the pre-OLM window no longer aborts the script. This covers both call sites (`start_bundle` and `validate_full_stack`).

## Verification

- `bash -n hack/install-konveyor.sh` passes.
- Minimal repro reproduces the exact log (two banner lines, then the subshell dies) with the old code, and the loop keeps polling with the fix.
- Failing run: https://github.com/konveyor/ci/actions/runs/33586929788/job/100144922763

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation reliability when the OLM resource is not yet available.
  * Prevented setup from stopping prematurely during best-effort environment checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->