### PR TITLE
:sparkles: Fix CVE-2026-11332: Update operator-sdk to v1.42.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG OPERATOR_SDK_VERSION=v1.37.1
+ARG OPERATOR_SDK_VERSION=v1.42.3
 FROM quay.io/operator-framework/ansible-operator:$OPERATOR_SDK_VERSION
 
 USER 0


### PR DESCRIPTION
## Summary
Fixes CVE-2026-11332 by updating operator-sdk from v1.37.1 to v1.42.3, which includes ansible-core 2.16.19+ containing the security fix.

## CVE Details
**CVE-2026-11332**: Argument injection in ansible-galaxy role install leads to arbitrary code execution

A flaw was found in ansible-core's ansible-galaxy command. When installing a role, ansible-galaxy processes a `meta/requirements.yml` file that lists role dependencies. The `src` and `name` fields from this file are passed as arguments to git clone via Python's Popen without a `--` separator to delimit options from positional arguments.

A malicious role author can craft a dependency entry where the `src` field contains a git configuration flag (e.g., `-ccore.sshCommand=sh -c "malicious_command"`) and the `name` field provides a valid repository URL. This results in arbitrary code execution on the system of any user who installs the role.

The fix inserts `--` before the positional arguments in the git clone command list.

## Changes
- Updated `Dockerfile`: `OPERATOR_SDK_VERSION=v1.37.1` → `v1.42.3`
- This brings in ansible-core 2.16.19+ which contains the CVE fix

## Affected Components
- mta/mta-rhel9-operator

## Jira Tickets
- Resolves: MTA-7414

## Test Plan
- [ ] Build operator image successfully
- [ ] Verify ansible-galaxy operations work correctly
- [ ] Run operator e2e tests
- [ ] Confirm ansible-core version >= 2.16.19 in built image

## Target Versions
- main (for backport to mta-8.1.4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the underlying operator runtime version used to build the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->