### PR TITLE
:sparkles: Add agentic-controller and related images to release

### DIFF
--- a/.github/actions/make-bundle/action.yml
+++ b/.github/actions/make-bundle/action.yml
@@ -69,6 +69,34 @@ inputs:
     description: "image uri for lightspeed-stack (ie. quay.io/<namespace>/<image-name>:<tag>)"
     required: false
     default: ""
+  agentic_controller:
+    description: "image uri for agentic-controller (ie. quay.io/<namespace>/<image-name>:<tag>)"
+    required: false
+    default: ""
+  agent_base:
+    description: "image uri for agent-base (ie. quay.io/<namespace>/<image-name>:<tag>)"
+    required: false
+    default: ""
+  agent_go:
+    description: "image uri for agent-go (ie. quay.io/<namespace>/<image-name>:<tag>)"
+    required: false
+    default: ""
+  agent_java:
+    description: "image uri for agent-java (ie. quay.io/<namespace>/<image-name>:<tag>)"
+    required: false
+    default: ""
+  agent_csharp:
+    description: "image uri for agent-csharp (ie. quay.io/<namespace>/<image-name>:<tag>)"
+    required: false
+    default: ""
+  agent_nodejs:
+    description: "image uri for agent-nodejs (ie. quay.io/<namespace>/<image-name>:<tag>)"
+    required: false
+    default: ""
+  agent_skills:
+    description: "image uri for agent-skills (ie. quay.io/<namespace>/<image-name>:<tag>)"
+    required: false
+    default: ""
   version:
     description: "operator version"
     required: false
@@ -110,6 +138,13 @@ runs:
       [ -n "${{ inputs.provider_c_sharp }}" ] && OPTS+=" --set images.provider_c_sharp=${{ inputs.provider_c_sharp }}"
       [ -n "${{ inputs.kantra }}" ] && OPTS+=" --set images.kantra=${{ inputs.kantra }}"
       [ -n "${{ inputs.lightspeed_stack }}" ] && OPTS+=" --set images.lightspeed_stack=${{ inputs.lightspeed_stack }}"
+      [ -n "${{ inputs.agentic_controller }}" ] && OPTS+=" --set images.agentic_controller=${{ inputs.agentic_controller }}"
+      [ -n "${{ inputs.agent_base }}" ] && OPTS+=" --set images.agent_base=${{ inputs.agent_base }}"
+      [ -n "${{ inputs.agent_go }}" ] && OPTS+=" --set images.agent_go=${{ inputs.agent_go }}"
+      [ -n "${{ inputs.agent_java }}" ] && OPTS+=" --set images.agent_java=${{ inputs.agent_java }}"
+      [ -n "${{ inputs.agent_csharp }}" ] && OPTS+=" --set images.agent_csharp=${{ inputs.agent_csharp }}"
+      [ -n "${{ inputs.agent_nodejs }}" ] && OPTS+=" --set images.agent_nodejs=${{ inputs.agent_nodejs }}"
+      [ -n "${{ inputs.agent_skills }}" ] && OPTS+=" --set images.agent_skills=${{ inputs.agent_skills }}"
       HELM_OPTS="${OPTS}" make bundle
       cat ./bundle/manifests/konveyor-operator.clusterserviceversion.yaml
       make bundle-build

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -234,12 +234,13 @@ jobs:
         tackle_postgres: quay.io/konveyor/postgresql-15-c9s:${{ inputs.version }}
         keycloak_sso: quay.io/konveyor/keycloak:${{ inputs.version }}
         lightspeed_stack: quay.io/konveyor/lightspeed-stack:${{ inputs.version }}
-        agentic_agent_base_fqin: quay.io/konveyor/agent-base:${{inputs.version}}
-        agentic_agent_go_fqin: quay.io/konveyor/agent-go:${{inputs.version}}
-        agentic_agent_java_fqin: quay.io/konveyor/agent-java:${{inputs.version}}
-        agentic_agent_csharp_fqin: quay.io/konveyor/agent-csharp:${{inputs.version}}
-        agentic_agent_nodejs_fqin: quay.io/konveyor/agent-nodejs:${{inputs.version}}
-        agentic_skills_fqin: quay.io/konveyor/skills:${{inputs.version}}
+        agentic_controller: quay.io/konveyor/agentic-controller:${{ inputs.version }}
+        agent_base: quay.io/konveyor/agent-base:${{ inputs.version }}
+        agent_go: quay.io/konveyor/agent-go:${{ inputs.version }}
+        agent_java: quay.io/konveyor/agent-java:${{ inputs.version }}
+        agent_csharp: quay.io/konveyor/agent-csharp:${{ inputs.version }}
+        agent_nodejs: quay.io/konveyor/agent-nodejs:${{ inputs.version }}
+        agent_skills: quay.io/konveyor/skills:${{ inputs.version }}
         # Bundle specific args
         version: ${{ inputs.version }}
         channels: ${{ inputs.operator_channels }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -150,7 +150,9 @@ jobs:
           - repo: konveyor/c-sharp-analyzer-provider
             image: konveyor/c-sharp-provider
           - repo: konveyor/agentic-controller
-            image: konveyor/agentic-controller
+            # skills is built last, so waiting on it confirms the
+            # agentic-controller and all agent-* images have published
+            image: konveyor/skills
       fail-fast: true
     steps:
       - uses: konveyor/release-tools/create-release@main

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -149,6 +149,8 @@ jobs:
             image: konveyor/kai-solution-server
           - repo: konveyor/c-sharp-analyzer-provider
             image: konveyor/c-sharp-provider
+          - repo: konveyor/agentic-controller
+            image: konveyor/agentic-controller
       fail-fast: true
     steps:
       - uses: konveyor/release-tools/create-release@main
@@ -232,6 +234,12 @@ jobs:
         tackle_postgres: quay.io/konveyor/postgresql-15-c9s:${{ inputs.version }}
         keycloak_sso: quay.io/konveyor/keycloak:${{ inputs.version }}
         lightspeed_stack: quay.io/konveyor/lightspeed-stack:${{ inputs.version }}
+        agentic_agent_base_fqin: quay.io/konveyor/agent-base:${{inputs.version}}
+        agentic_agent_go_fqin: quay.io/konveyor/agent-go:${{inputs.version}}
+        agentic_agent_java_fqin: quay.io/konveyor/agent-java:${{inputs.version}}
+        agentic_agent_csharp_fqin: quay.io/konveyor/agent-csharp:${{inputs.version}}
+        agentic_agent_nodejs_fqin: quay.io/konveyor/agent-nodejs:${{inputs.version}}
+        agentic_skills_fqin: quay.io/konveyor/skills:${{inputs.version}}
         # Bundle specific args
         version: ${{ inputs.version }}
         channels: ${{ inputs.operator_channels }}
@@ -351,6 +359,7 @@ jobs:
           "konveyor/operator"
           "konveyor/kantra"
           "konveyor/kai"
+          "konveyor/agentic-controller"
         )
 
         echo "Konveyor Operator ${{ inputs.version }}" > changelog.md


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the release process to verify the Skills component image after all Agentic images are published.
  - Expanded release bundles to include images for the Agentic Controller, base, Go, Java, C#, Node.js, and Skills components.
  - Continued including Agentic Controller changes in unified release changelogs.
  - Added support for configuring the expanded set of Agentic component images during bundle creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->