### PR TITLE
:bug: Distinguish OLM probe failures from missing CRD in get_olm_namespace

### DIFF
--- a/hack/install-konveyor.sh
+++ b/hack/install-konveyor.sh
@@ -204,14 +204,15 @@ start_agent_sandbox() {
 # uses 'olm', while OpenShift ships it in 'openshift-operator-lifecycle-manager'.
 # The packageserver CSV lives in the OLM namespace in both cases.
 #
-# This is a best-effort probe: before OLM is installed the
-# clusterserviceversions CRD does not exist yet, so kubectl exits non-zero.
-# The trailing '|| true' keeps that non-zero from tripping 'set -e' (and
-# 'set -o pipefail') when the result is assigned in a bare command
-# substitution by callers, e.g. `olm_namespace=$(get_olm_namespace)`.
+# Listing CRDs succeeds whenever the API is reachable, so a failure there is a
+# genuine error (return 1, caller fails fast); a missing CSV CRD just means OLM
+# isn't installed yet (return empty, caller retries).
 get_olm_namespace() {
-  kubectl get clusterserviceversions.operators.coreos.com --all-namespaces 2>/dev/null \
-    | awk '/packageserver/ {print $1; exit}' || true
+  local crds
+  crds=$(kubectl get crd -o name) || return 1
+  grep -qx 'customresourcedefinition.apiextensions.k8s.io/clusterserviceversions.operators.coreos.com' <<<"${crds}" || return 0
+  kubectl get clusterserviceversions.operators.coreos.com --all-namespaces \
+    | awk '/packageserver/ {print $1; exit}'
 }
 
 start_bundle() {


### PR DESCRIPTION
## Description

`get_olm_namespace()` was made best-effort in #598 with a trailing `|| true`
so a non-zero `kubectl` exit during the pre-OLM window would not abort the
script under `set -e` / `set -o pipefail`. That broad suppression also hides
genuine failures such as API server unavailability or insufficient RBAC,
leaving callers (`start_bundle`, `validate_full_stack`) with no signal.

This PR splits the two cases:

- **List CRDs first.** A failure there means the API is unreachable or RBAC is
  denied → `return 1` and let the caller fail fast. The `kubectl` error is no
  longer swallowed by `2>/dev/null`, so it stays visible to the user.
- **CSV CRD absent** → OLM simply isn't installed yet → return empty (exit 0)
  so the caller keeps polling (preserves the #598 behavior).
- **Otherwise** → resolve the `packageserver` CSV's namespace as before.

## Fixes

Fixes #601

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of cluster API availability during installation.
  * Installation now distinguishes between unavailable cluster access and OLM not being installed, allowing failures to be reported earlier and more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->