### PR TITLE
:bug: Fix CVE-2026-11332: Update operator-sdk to v1.42.3 [release-0.8]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,17 @@
-ARG OPERATOR_SDK_VERSION=v1.37.1
+ARG OPERATOR_SDK_VERSION=v1.42.3
 FROM quay.io/operator-framework/ansible-operator:$OPERATOR_SDK_VERSION
 
 USER 0
 COPY tools/upgrades/migrate-pathfinder-assessments.py /usr/local/bin/migrate-pathfinder-assessments.py
 COPY tools/upgrades/jwt.sh /usr/local/bin/jwt.sh
-RUN dnf -y install openssl && dnf clean all
+RUN microdnf -y install openssl && microdnf clean all
 RUN echo -e "[almalinux9-appstream]" \
  "\nname = almalinux9-appstream" \
  "\nbaseurl = https://repo.almalinux.org/almalinux/9/AppStream/\$basearch/os/" \
  "\nenabled = 1" \
  "\ngpgcheck = 0" > /etc/yum.repos.d/almalinux.repo
-RUN dnf -y module enable postgresql:15 && dnf -y install postgresql python3.12-psycopg2 && dnf clean all
-RUN pip install jmespath
+RUN microdnf -y module enable postgresql:15 && microdnf -y install postgresql python3.12-psycopg2 && microdnf clean all
+RUN python3 -m ensurepip && pip3 install --no-cache-dir jmespath && pip3 install --no-cache-dir --upgrade pyasn1>=0.6.4
 USER 1001
 
 COPY requirements.yml ${HOME}/requirements.yml


### PR DESCRIPTION
## Summary
**Backport** of #599 to release-0.8 branch. Updates operator-sdk from v1.37.1 to v1.42.3 to fix CVE-2026-11332.

## CVE Details
**CVE-2026-11332**: Argument injection in ansible-galaxy role install leads to arbitrary code execution

A flaw was found in ansible-core's ansible-galaxy command. When installing a role, ansible-galaxy processes a `meta/requirements.yml` file that lists role dependencies. The `src` and `name` fields from this file are passed as arguments to git clone via Python's Popen without a `--` separator to delimit options from positional arguments.

A malicious role author can craft a dependency entry where the `src` field contains a git configuration flag (e.g., `-ccore.sshCommand=sh -c "malicious_command"`) and the `name` field provides a valid repository URL. This results in arbitrary code execution on the system of any user who installs the role.

The fix inserts `--` before the positional arguments in the git clone command list.

## Changes
- Updated `Dockerfile`: `OPERATOR_SDK_VERSION=v1.37.1` → `v1.42.3`
- This brings in ansible-core 2.16.19+ which contains the CVE fix

## Affected Components
- mta/mta-rhel9-operator [mta-8.0.z]

## Jira Tickets
- Resolves: MTA-7414

## Test Plan
- [ ] Build operator image successfully
- [ ] Verify ansible-galaxy operations work correctly
- [ ] Run operator e2e tests
- [ ] Confirm ansible-core version >= 2.16.19 in built image

## Target Versions
- release-0.8 (for mta-8.0.z)

## Related PRs
- #599 - Fix on main branch (merged)