### PR TITLE
:sparkles: Install agentic-controller default content

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -54,5 +54,8 @@ jobs:
     uses: konveyor/ci/.github/workflows/global-ci-bundle.yml@main
     with:
       operator_bundle: ttl.sh/konveyor-operator-bundle-${{ github.sha }}:2h
+      # Fetch tackle-k8s.yaml from the branch this PR targets (always a konveyor
+      # org branch); github.head_ref would point at a fork and 404.
+      ref: ${{ github.base_ref || github.ref_name }}
       run_koncur_hub_tests: true
       run_koncur_kantra_tests: true

--- a/README.md
+++ b/README.md
@@ -98,6 +98,33 @@ You can access the Konveyor UI in your browser through the `$(minikube ip)` IP.
 
 If you're looking to install Konveyor operator on macOS, follow the guide [here](docs/installation-macos.md).
 
+### Enabling the agentic controller (alpha)
+
+The agentic controller is an opt-in, alpha operand. Turn it on by setting
+`agentic_enabled: true` in the Tackle CR spec:
+
+```
+spec:
+  agentic_enabled: true
+```
+
+The agentic controller requires [Agent Sandbox](https://github.com/kubernetes-sigs/agent-sandbox)
+to be installed in the cluster first: it watches and owns `Sandbox`
+(`sandboxes.agents.x-k8s.io`) objects, so the operator only deploys it once that
+CRD is present. Until then the operator posts an `AgenticControllerReady`
+condition with reason `AgentSandboxMissing` and does not deploy the controller.
+Agent Sandbox is a separate project, not an operator-managed operand; install it
+either by applying an upstream [release manifest](https://github.com/kubernetes-sigs/agent-sandbox/releases)
+or from its operator (available on [OperatorHub](https://operatorhub.io/) and in
+the OpenShift catalog).
+
+For local development, `hack/install-konveyor.sh` can install the Agent Sandbox
+prerequisite and enable the controller in one step:
+
+```
+INSTALL_AGENT_SANDBOX=true AGENTIC_ENABLED=true ./hack/install-konveyor.sh
+```
+
 ## Konveyor Operator Installation on OKD/OpenShift
 
 ### Installing _released versions_

--- a/bundle/manifests/konveyor-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/konveyor-operator.clusterserviceversion.yaml
@@ -148,7 +148,7 @@ metadata:
     categories: Modernization & Migration
     certified: "false"
     containerImage: quay.io/konveyor/tackle2-operator:latest
-    createdAt: "2026-09-08T14:57:56Z"
+    createdAt: "2026-09-09T01:49:10Z"
     description: Konveyor is an open-source application modernization platform that
       helps organizations safely and predictably modernize applications to Kubernetes
       at scale.
@@ -748,6 +748,21 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups:
+          - konveyor.io
+          resources:
+          - agents
+          - agentworkflows
+          - skillcards
+          - skillcollections
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
         serviceAccountName: tackle-operator
     strategy: deployment
   installModes:

--- a/hack/install-konveyor.sh
+++ b/hack/install-konveyor.sh
@@ -26,6 +26,11 @@ AGENT_SANDBOX_VERSION="${AGENT_SANDBOX_VERSION:-v1.0.0}"
 # sandbox-with-extensions.yaml (core + extensions). Core is enough for the
 # agentic controller.
 AGENT_SANDBOX_MANIFEST="${AGENT_SANDBOX_MANIFEST:-sandbox.yaml}"
+# Turn on the agentic controller in the generated Tackle CR. Pair with
+# INSTALL_AGENT_SANDBOX=true so the Sandbox CRD is present, or the controller
+# is gated off with an AgentSandboxMissing condition. Unset leaves the operator
+# default (false). Ignored when TACKLE_CR is supplied.
+AGENTIC_ENABLED="${AGENTIC_ENABLED:-}"
 
 # Global timeout configuration - entire script must complete within this time
 GLOBAL_TIMEOUT_SECONDS="${GLOBAL_TIMEOUT_SECONDS:-600}"  # 10 minutes default
@@ -296,6 +301,7 @@ metadata:
 spec:
   disable_maven_search: ${DISABLE_MAVEN_SEARCH}
   feature_auth_required: ${FEATURE_AUTH_REQUIRED}
+${AGENTIC_ENABLED:+  agentic_enabled: ${AGENTIC_ENABLED}}
 ${KAI_SOLUTION_SERVER_ENABLED:+  kai_solution_server_enabled: ${KAI_SOLUTION_SERVER_ENABLED}}
 ${KAI_LLM_MODEL:+  kai_llm_model: ${KAI_LLM_MODEL}}
 ${KAI_LLM_PROVIDER:+  kai_llm_provider: ${KAI_LLM_PROVIDER}}

--- a/helm/templates/rbac/role.yaml
+++ b/helm/templates/rbac/role.yaml
@@ -111,4 +111,22 @@ rules:
   - patch
   - update
   - watch
+# The operator applies and prunes curated agentic defaults, including cleanup
+# when agentic is disabled. The agentic-controller's RBAC does not cover these
+# requests because they run as the tackle-operator service account.
+- apiGroups:
+  - konveyor.io
+  resources:
+  - agents
+  - agentworkflows
+  - skillcards
+  - skillcollections
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
 #+kubebuilder:scaffold:rules

--- a/roles/tackle/tasks/agentic-defaults.yml
+++ b/roles/tackle/tasks/agentic-defaults.yml
@@ -1,0 +1,99 @@
+---
+# Install the agentic controller's curated default content: the SkillCards,
+# SkillCollection, stage Agents, and the AgentWorkflow the UI lists so a user
+# has something to run out of the box. These manifests are authored in
+# konveyor/agentic-controller (config/defaults/) and synced verbatim into
+# templates/agentic/defaults/ by that repo's sync-operator workflow -- do NOT
+# hand-edit them here; re-sync instead.
+#
+# They are plain konveyor.io CRs (no Jinja), so each file is applied as-is via
+# the k8s module's `src`. They depend only on the agentic controller's own CRDs
+# (installed with the operand through the OLM bundle), not on the Agent Sandbox
+# CRD. We gate them on agentic_state (enabled AND controller deployable) so the
+# cluster never carries curated content without a controller to reconcile it --
+# the same switch that governs the Deployment.
+#
+# CLOBBER POLICY: state: present with server-side apply (server_side_apply with a
+# stable field_manager) re-asserts the declared fields on every reconcile. These
+# are product-owned defaults, so the operator keeps them canonical -- force_conflicts
+# makes a hand-edit to a shipped SkillCard revert next reconcile (SSA would
+# otherwise error on the competing field manager), exactly like the controller
+# Deployment. Customers who want their own content should create a new
+# SkillCard/Agent, not edit these.
+#
+# PRUNING: the apply loop is create-or-update only, so a default removed from
+# config/defaults/ upstream stops being re-created but the object already in the
+# cluster would linger. The prune tasks below remove those orphans. They are
+# safe because every curated CR carries the marker label
+# app.kubernetes.io/managed-by: agentic-controller-defaults (set at the source in
+# agentic-controller): the prune only ever lists and deletes objects bearing that
+# label, so user-created SkillCards/Agents -- which never have it -- are untouched.
+#
+# The synced directory does not exist until the first agentic-controller sync
+# lands, so `find` is written to tolerate its absence (empty result, no error).
+
+- name: Discover agentic default manifests
+  find:
+    paths: "{{ role_path }}/templates/agentic/defaults"
+    patterns: "*.yaml"
+    file_type: file
+  register: agentic_defaults
+
+- name: Apply agentic controller default content
+  k8s:
+    state: "{{ agentic_state }}"
+    namespace: "{{ app_namespace }}"
+    src: "{{ item }}"
+    apply: true
+    server_side_apply:
+      field_manager: agentic-controller-defaults
+      force_conflicts: true
+  loop: "{{ agentic_defaults.files | map(attribute='path') | sort }}"
+  loop_control:
+    label: "{{ item | basename }}"
+
+# --- Prune curated defaults removed from the catalog -------------------------
+# Only when the content is meant to be present; when agentic_state is absent the
+# apply loop above already deletes each shipped default, so there is nothing to
+# reconcile here.
+
+- name: Record the desired default identities (kind/name)
+  set_fact:
+    agentic_desired_defaults: >-
+      {{ agentic_desired_defaults | default([])
+         + [ (lookup('file', item) | from_yaml).kind
+             ~ '/' ~ (lookup('file', item) | from_yaml).metadata.name ] }}
+  loop: "{{ agentic_defaults.files | map(attribute='path') | sort }}"
+  loop_control:
+    label: "{{ item | basename }}"
+  when: agentic_state == 'present'
+
+- name: List installed curated defaults
+  k8s_info:
+    api_version: konveyor.io/v1alpha1
+    kind: "{{ item }}"
+    namespace: "{{ app_namespace }}"
+    label_selectors:
+      - "app.kubernetes.io/managed-by=agentic-controller-defaults"
+  register: agentic_installed_defaults
+  loop:
+    - Agent
+    - AgentWorkflow
+    - SkillCard
+    - SkillCollection
+  when: agentic_state == 'present'
+
+- name: Prune curated defaults no longer in the catalog
+  k8s:
+    state: absent
+    api_version: konveyor.io/v1alpha1
+    kind: "{{ item.kind }}"
+    namespace: "{{ app_namespace }}"
+    name: "{{ item.metadata.name }}"
+  loop: "{{ (agentic_installed_defaults.results | default([]))
+            | map(attribute='resources') | flatten }}"
+  loop_control:
+    label: "{{ item.kind }}/{{ item.metadata.name }}"
+  when:
+    - agentic_state == 'present'
+    - (item.kind ~ '/' ~ item.metadata.name) not in (agentic_desired_defaults | default([]))

--- a/roles/tackle/tasks/agentic-defaults.yml
+++ b/roles/tackle/tasks/agentic-defaults.yml
@@ -36,12 +36,16 @@
   find:
     paths: "{{ role_path }}/templates/agentic/defaults"
     patterns: "*.yaml"
+    # The sync strips config/defaults/kustomization.yaml, but exclude it
+    # defensively: it is a Kustomize control file, not a CR, so it has no
+    # metadata.name and would break the apply and identity loops.
+    excludes: "kustomization.yaml"
     file_type: file
   register: agentic_defaults
 
 - name: Apply agentic controller default content
   k8s:
-    state: "{{ agentic_state }}"
+    state: present
     namespace: "{{ app_namespace }}"
     src: "{{ item }}"
     apply: true
@@ -51,11 +55,19 @@
   loop: "{{ agentic_defaults.files | map(attribute='path') | sort }}"
   loop_control:
     label: "{{ item | basename }}"
+  when: agentic_state == 'present'
 
-# --- Prune curated defaults removed from the catalog -------------------------
-# Only when the content is meant to be present; when agentic_state is absent the
-# apply loop above already deletes each shipped default, so there is nothing to
-# reconcile here.
+# --- Prune curated defaults not in the desired set ---------------------------
+# The prune, not the apply loop, owns all deletion, and it runs in BOTH states:
+#   - present: the desired set is the currently-synced catalog, so prune removes
+#     only defaults that a newer catalog dropped (orphans).
+#   - absent: the desired set is empty (the identity task below is skipped, so
+#     agentic_desired_defaults defaults to []), so prune removes every curated
+#     default -- disabling the feature must also clean up defaults that an older
+#     catalog installed but the current one no longer ships.
+# It is safe in both cases because it only ever lists and deletes objects
+# carrying the app.kubernetes.io/managed-by marker label; user-created
+# SkillCards/Agents never have it and are untouched.
 
 - name: Record the desired default identities (kind/name)
   set_fact:
@@ -81,9 +93,8 @@
     - AgentWorkflow
     - SkillCard
     - SkillCollection
-  when: agentic_state == 'present'
 
-- name: Prune curated defaults no longer in the catalog
+- name: Prune curated defaults no longer in the desired set
   k8s:
     state: absent
     api_version: konveyor.io/v1alpha1
@@ -94,6 +105,4 @@
             | map(attribute='resources') | flatten }}"
   loop_control:
     label: "{{ item.kind }}/{{ item.metadata.name }}"
-  when:
-    - agentic_state == 'present'
-    - (item.kind ~ '/' ~ item.metadata.name) not in (agentic_desired_defaults | default([]))
+  when: (item.kind ~ '/' ~ item.metadata.name) not in (agentic_desired_defaults | default([]))

--- a/roles/tackle/tasks/agentic.yml
+++ b/roles/tackle/tasks/agentic.yml
@@ -30,6 +30,9 @@
     template: agentic/deployment.yaml.j2
     merge_type: merge
 
+- name: Install (or remove) agentic controller default content
+  import_tasks: agentic-defaults.yml
+
 - name: Update agentic controller status conditions
   when: ansible_operator_meta is defined
   import_tasks: agentic-status.yml

--- a/test/rbac/test_agentic_defaults_rbac.py
+++ b/test/rbac/test_agentic_defaults_rbac.py
@@ -1,0 +1,75 @@
+"""Check the permissions used by the operator's curated-defaults tasks.
+
+Run with `python3 -m unittest discover -s test/rbac -v`.
+Requires PyYAML and Helm; set HELM to override the Helm executable.
+"""
+
+import os
+from pathlib import Path
+import subprocess
+import unittest
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+RESOURCES = ("agents", "agentworkflows", "skillcards", "skillcollections")
+VERBS = ("get", "list", "watch", "create", "update", "patch", "delete")
+
+
+class AgenticDefaultsRBACTest(unittest.TestCase):
+    def assert_curated_permissions(self, rules):
+        for resource in RESOURCES:
+            for verb in VERBS:
+                with self.subTest(resource=resource, verb=verb):
+                    self.assertTrue(
+                        any(
+                            "konveyor.io" in rule.get("apiGroups", [])
+                            and resource in rule.get("resources", [])
+                            and verb in rule.get("verbs", [])
+                            and not rule.get("resourceNames")
+                            for rule in rules
+                        ),
+                        f"tackle-operator needs {verb} on {resource}.konveyor.io",
+                    )
+
+    def test_helm_grants_namespaced_permissions_to_operator(self):
+        rendered = subprocess.check_output(
+            [os.environ.get("HELM", "helm"), "template", "test", str(ROOT / "helm")],
+            text=True,
+        )
+        objects = list(yaml.safe_load_all(rendered))
+        bound_roles = {
+            obj["roleRef"]["name"]
+            for obj in objects
+            if obj and obj["kind"] == "RoleBinding"
+            and obj["roleRef"]["kind"] == "Role"
+            and any(
+                subject["kind"] == "ServiceAccount"
+                and subject["name"] == "tackle-operator"
+                for subject in obj["subjects"]
+            )
+        }
+        rules = [
+            rule
+            for obj in objects
+            if obj and obj["kind"] == "Role" and obj["metadata"]["name"] in bound_roles
+            for rule in obj["rules"]
+        ]
+        self.assert_curated_permissions(rules)
+
+    def test_bundle_grants_namespaced_permissions_to_operator(self):
+        csv = yaml.safe_load(
+            (ROOT / "bundle/manifests/konveyor-operator.clusterserviceversion.yaml").read_text()
+        )
+        rules = [
+            rule
+            for permission in csv["spec"]["install"]["spec"]["permissions"]
+            if permission["serviceAccountName"] == "tackle-operator"
+            for rule in permission["rules"]
+        ]
+        self.assert_curated_permissions(rules)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The operator installs the agentic controller's curated SkillCards, SkillCollection, Agents, and AgentWorkflow so users have a workflow available when agentic is enabled. It also removes previously installed curated defaults when agentic is disabled or the catalog drops them.

## Behavior

- Discover the synced manifests in `roles/tackle/templates/agentic/defaults/`, excluding `kustomization.yaml`.
- Apply the catalog with server-side apply when `agentic_state` is `present`, reasserting the shipped content on reconcile.
- List and prune resources carrying `app.kubernetes.io/managed-by=agentic-controller-defaults`. Cleanup also runs when agentic is disabled; resources without that marker are preserved.
- Grant the `tackle-operator` service account namespace-scoped `get/list/watch/create/update/patch/delete` permissions for `agents`, `agentworkflows`, `skillcards`, and `skillcollections`, and regenerate the OLM bundle. These permissions prevent the cleanup task from failing Tackle reconciliation with `403 Forbidden`.

## Default content

The manifests are authored in `konveyor/agentic-controller` and synced into the operator by its sync workflow (see #605). A missing defaults directory is tolerated: no manifests are applied, and previously installed marked defaults are pruned against the empty catalog.

## Validation

- Regression tests check the operator service account's namespace-scoped permissions in the rendered Helm chart and generated CSV. They fail without the RBAC fix and pass with it.
- `python3 -m unittest discover -s test/rbac -v` (requires Helm and PyYAML)
- OLM bundle validation and Helm lint pass locally.
- CI is rerunning with the cleanup task and required RBAC together.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for installing curated default content for the agentic controller, including agents, workflows, skills, and collections.
  - Default content is applied when the agentic controller is enabled and synchronized from the configured manifests.
  - Managed defaults are automatically pruned when they are no longer included in the desired configuration.
  - If no curated defaults are configured, previously managed default content is removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
