### PR TITLE
:bug: Grant operator access to curated agentic defaults

### DIFF
--- a/bundle/manifests/konveyor-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/konveyor-operator.clusterserviceversion.yaml
@@ -148,7 +148,7 @@ metadata:
     categories: Modernization & Migration
     certified: "false"
     containerImage: quay.io/konveyor/tackle2-operator:latest
-    createdAt: "2026-08-27T20:07:33Z"
+    createdAt: "2026-09-08T20:05:40Z"
     description: Konveyor is an open-source application modernization platform that
       helps organizations safely and predictably modernize applications to Kubernetes
       at scale.
@@ -745,6 +745,21 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups:
+          - konveyor.io
+          resources:
+          - agents
+          - agentworkflows
+          - skillcards
+          - skillcollections
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
         serviceAccountName: tackle-operator
     strategy: deployment
   installModes:

--- a/helm/templates/rbac/role.yaml
+++ b/helm/templates/rbac/role.yaml
@@ -111,4 +111,22 @@ rules:
   - patch
   - update
   - watch
+# The operator applies and prunes curated agentic defaults, including cleanup
+# when agentic is disabled. The agentic-controller's RBAC does not cover these
+# requests because they run as the tackle-operator service account.
+- apiGroups:
+  - konveyor.io
+  resources:
+  - agents
+  - agentworkflows
+  - skillcards
+  - skillcollections
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
 #+kubebuilder:scaffold:rules

--- a/test/rbac/test_agentic_defaults_rbac.py
+++ b/test/rbac/test_agentic_defaults_rbac.py
@@ -1,0 +1,75 @@
+"""Check the permissions used by the operator's curated-defaults tasks.
+
+Run with `python3 -m unittest discover -s test/rbac -v`.
+Requires PyYAML and Helm; set HELM to override the Helm executable.
+"""
+
+import os
+from pathlib import Path
+import subprocess
+import unittest
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+RESOURCES = ("agents", "agentworkflows", "skillcards", "skillcollections")
+VERBS = ("get", "list", "watch", "create", "update", "patch", "delete")
+
+
+class AgenticDefaultsRBACTest(unittest.TestCase):
+    def assert_curated_permissions(self, rules):
+        for resource in RESOURCES:
+            for verb in VERBS:
+                with self.subTest(resource=resource, verb=verb):
+                    self.assertTrue(
+                        any(
+                            "konveyor.io" in rule.get("apiGroups", [])
+                            and resource in rule.get("resources", [])
+                            and verb in rule.get("verbs", [])
+                            and not rule.get("resourceNames")
+                            for rule in rules
+                        ),
+                        f"tackle-operator needs {verb} on {resource}.konveyor.io",
+                    )
+
+    def test_helm_grants_namespaced_permissions_to_operator(self):
+        rendered = subprocess.check_output(
+            [os.environ.get("HELM", "helm"), "template", "test", str(ROOT / "helm")],
+            text=True,
+        )
+        objects = list(yaml.safe_load_all(rendered))
+        bound_roles = {
+            obj["roleRef"]["name"]
+            for obj in objects
+            if obj and obj["kind"] == "RoleBinding"
+            and obj["roleRef"]["kind"] == "Role"
+            and any(
+                subject["kind"] == "ServiceAccount"
+                and subject["name"] == "tackle-operator"
+                for subject in obj["subjects"]
+            )
+        }
+        rules = [
+            rule
+            for obj in objects
+            if obj and obj["kind"] == "Role" and obj["metadata"]["name"] in bound_roles
+            for rule in obj["rules"]
+        ]
+        self.assert_curated_permissions(rules)
+
+    def test_bundle_grants_namespaced_permissions_to_operator(self):
+        csv = yaml.safe_load(
+            (ROOT / "bundle/manifests/konveyor-operator.clusterserviceversion.yaml").read_text()
+        )
+        rules = [
+            rule
+            for permission in csv["spec"]["install"]["spec"]["permissions"]
+            if permission["serviceAccountName"] == "tackle-operator"
+            for rule in permission["rules"]
+        ]
+        self.assert_curated_permissions(rules)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
PR #604 adds operator-driven apply/prune tasks for curated agentic defaults, but `tackle-operator` has no permissions for those resources. Its unconditional cleanup listing fails with `403 Forbidden` even when agentic is disabled, preventing Tackle reconciliation and failing the LLM/API installation jobs. The existing grants belong to the separate `agentic-controller` service account.

Grant `tackle-operator` namespace-scoped `get/list/watch/create/update/patch/delete` access to `agents`, `agentworkflows`, `skillcards`, and `skillcollections`, and regenerate the OLM bundle. This is a standalone prerequisite fix for #604, based on `main`.

Validation:

- Added regression checks against the rendered Helm RoleBindings/Roles and generated CSV permissions for the operator service account. Both failed before the fix and pass afterward.
- `python3 -m unittest discover -s test/rbac -v` (requires Helm and PyYAML)
- `make bundle` and `helm lint helm` pass.
- Live cleanup reconciliation must be confirmed after #604 is rebased onto this fix; its cleanup task is not part of this standalone PR.

Evidence: [failing API job](https://github.com/konveyor/operator/actions/runs/34259968418/job/102175891131), [failing LLM job](https://github.com/konveyor/operator/actions/runs/34259967656/job/102175166830). Both runs' operator debug artifacts show the missing `konveyor.io` permissions on `tackle-operator`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The operator can now create, update, monitor, and remove curated agent workflows, agents, skill cards, and skill collections.
  - Support is included across both Helm-based installations and the bundled deployment configuration.

- **Tests**
  - Added coverage to verify that the required permissions are consistently granted in both deployment formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->