### PR TITLE
:bug: Grant tackle-hub RBAC for agentic CRs

### DIFF
--- a/bundle/manifests/konveyor-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/konveyor-operator.clusterserviceversion.yaml
@@ -148,7 +148,7 @@ metadata:
     categories: Modernization & Migration
     certified: "false"
     containerImage: quay.io/konveyor/tackle2-operator:latest
-    createdAt: "2026-09-09T14:40:56Z"
+    createdAt: "2026-09-11T12:58:07Z"
     description: Konveyor is an open-source application modernization platform that
       helps organizations safely and predictably modernize applications to Kubernetes
       at scale.
@@ -635,6 +635,18 @@ spec:
           - batch
           resources:
           - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - konveyor.io
+          resources:
+          - agents
+          - agentruns
+          - agentworkflows
+          - agentworkflowruns
+          - gateways
+          - skillcards
+          - skillcollections
           verbs:
           - '*'
         - apiGroups:

--- a/helm/templates/rbac/hub_role.yaml
+++ b/helm/templates/rbac/hub_role.yaml
@@ -12,6 +12,22 @@ rules:
   - '*'
   verbs:
   - '*'
+# The agentic CRDs are served under the bare konveyor.io group rather than
+# tackle.konveyor.io, so the wildcard above does not cover them. Name each
+# resource explicitly (rather than wildcarding the whole konveyor.io group) so
+# the hub is only granted the agentic CRs it manages.
+- apiGroups:
+  - konveyor.io
+  resources:
+  - agents
+  - agentruns
+  - agentworkflows
+  - agentworkflowruns
+  - gateways
+  - skillcards
+  - skillcollections
+  verbs:
+  - '*'
 - apiGroups:
   - security.openshift.io
   resourceNames:


### PR DESCRIPTION
## What

Adds an explicit `konveyor.io` rule to `tackle-hub-role` (and regenerates the bundle CSV) granting the `tackle-hub` service account access to the agentic custom resources: `agents`, `agentruns`, `agentworkflows`, `agentworkflowruns`, `gateways`, `skillcards`, `skillcollections`.

## Why

The agentic CRDs are served under the bare `konveyor.io` API group rather than `tackle.konveyor.io`. The hub Role already grants a wildcard (`*/*`) on `""`, `tackle.konveyor.io`, and `batch` — but that does **not** cover the bare `konveyor.io` group, so the hub currently has no access to these resources.

This follows up on the review of #604, which noted these permissions belong on the `tackle-hub` service account. The permissions #604 added to `tackle-operator` remain correct and separate: the operator only needs them to seed/prune the curated default content (Agent/AgentWorkflow/SkillCard/SkillCollection), whereas the hub needs to read and manage the full agentic resource set at runtime.

## Notes

- Each resource is named explicitly rather than wildcarding the whole `konveyor.io` group, so the grant stays scoped to the agentic CRs even if that group grows to include unrelated resources.
- Bundle CSV regenerated via `make bundle`; the new rule lands in the `tackle-hub` permissions block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Expanded platform support for agentic workflows and related resources.
  - Updated service permissions to enable management of agents, runs, gateways, skill cards, and skill collections.
  - Updated the release metadata timestamp for the September 11, 2026 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->