### PR TITLE
:bug: Wait for all release images before building the bundle

### DIFF
--- a/.github/actions/make-bundle/action.yml
+++ b/.github/actions/make-bundle/action.yml
@@ -37,6 +37,10 @@ inputs:
     description: "image uri for analyzer addon (ie. quay.io/<namespace>/<image-name>:<tag>)"
     required: false
     default: ""
+  addon_platform:
+    description: "image uri for platform addon (ie. quay.io/konveyor/tackle2-addon-platform:tag)"
+    required: false
+    default: ""
   addon_discovery:
     description: "image uri for discovery addon (ie. quay.io/<namespace>/<image-name>:<tag>)"
     required: false
@@ -105,6 +109,10 @@ inputs:
     description: "comma separated channel(s) this operator should be available on"
     required: false
     default: ""
+  build_bundle:
+    description: "Build the bundle image after generating manifests"
+    required: false
+    default: "true"
   push_bundle:
     description: ""
     required: false
@@ -130,6 +138,7 @@ runs:
       [ -n "${{ inputs.keycloak_sso }}" ] && OPTS+=" --set images.keycloak_sso=${{ inputs.keycloak_sso }}"
       [ -n "${{ inputs.tackle_ui }}" ] && OPTS+=" --set images.tackle_ui=${{ inputs.tackle_ui }}"
       [ -n "${{ inputs.addon_analyzer }}" ] && OPTS+=" --set images.addon_analyzer=${{ inputs.addon_analyzer }}"
+      [ -n "${{ inputs.addon_platform }}" ] && OPTS+=" --set images.addon_platform=${{ inputs.addon_platform }}"
       [ -n "${{ inputs.addon_discovery }}" ] && OPTS+=" --set images.addon_discovery=${{ inputs.addon_discovery }}"
       [ -n "${{ inputs.provider_go }}" ] && OPTS+=" --set images.provider_go=${{ inputs.provider_go }}"
       [ -n "${{ inputs.provider_python }}" ] && OPTS+=" --set images.provider_python=${{ inputs.provider_python }}"
@@ -147,7 +156,9 @@ runs:
       [ -n "${{ inputs.agent_skills }}" ] && OPTS+=" --set images.agent_skills=${{ inputs.agent_skills }}"
       HELM_OPTS="${OPTS}" make bundle
       cat ./bundle/manifests/konveyor-operator.clusterserviceversion.yaml
-      make bundle-build
+      if [ "${{ inputs.build_bundle }}" = "true" ]; then
+        make bundle-build
+      fi
     working-directory: ${{ github.action_path }}/../../..
     shell: bash
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -131,53 +131,32 @@ jobs:
     strategy:
       matrix:
         projects:
-          - repo: konveyor/tackle2-hub
-            image: konveyor/tackle2-hub
-          - repo: konveyor/tackle2-ui
-            image: konveyor/tackle2-ui
-          - repo: konveyor/tackle2-addon
-            image: ''
-          - repo: konveyor/tackle2-seed
-            image: ''
-          - repo: konveyor/operator
-            image: konveyor/tackle2-operator
-          - repo: konveyor/kantra
-            image: konveyor/kantra
-          - repo: konveyor/tackle2-addon-discovery
-            image: konveyor/tackle2-addon-discovery
-          - repo: konveyor/kai
-            image: konveyor/kai-solution-server
-          - repo: konveyor/c-sharp-analyzer-provider
-            image: konveyor/c-sharp-provider
-          - repo: konveyor/agentic-controller
-            # skills is built last, so waiting on it confirms the
-            # agentic-controller and all agent-* images have published
-            image: konveyor/skills
+          - konveyor/tackle2-hub
+          - konveyor/tackle2-ui
+          - konveyor/tackle2-addon
+          - konveyor/tackle2-seed
+          - konveyor/operator
+          - konveyor/kantra
+          - konveyor/tackle2-addon-discovery
+          - konveyor/kai
+          - konveyor/c-sharp-analyzer-provider
+          - konveyor/agentic-controller
       fail-fast: true
     steps:
       - uses: konveyor/release-tools/create-release@main
         with:
           version: ${{ inputs.version }}
           prev_version: ${{ inputs.previous_version }}
-          repository: ${{ matrix.projects.repo }}
+          repository: ${{ matrix.projects }}
           ref: ${{ inputs.branch }}
           github_token: ${{ secrets.GH_TOKEN }}
-      - if: ${{ matrix.projects.image != '' }}
-        run: |
-          #!/bin/bash
-          while ! docker pull quay.io/${{ matrix.projects.image }}:${{ inputs.version }} &> /dev/null; do
-              sleep 3m
-          done
-          docker image inspect quay.io/${{ matrix.projects.image }}:${{ inputs.version }}
 
-  build-bundle:
-    name: Build Bundle Manifest
+  prepare-bundle:
+    name: Prepare Bundle Manifests
     needs: release-components
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
     steps:
-    - name: Checkout Push to Registry action
+    - name: Checkout operator
       uses: actions/checkout@v4
       with:
         path: operator
@@ -215,14 +194,16 @@ jobs:
             fi
         done
 
-    - name: Build bundle
+    - name: Generate bundle manifests
       uses: ./operator/.github/actions/make-bundle
       with:
+        build_bundle: 'false'
         operator_bundle: quay.io/konveyor/tackle2-operator-bundle:${{ inputs.version }}
         operator: quay.io/konveyor/tackle2-operator:${{ inputs.version }}
         tackle_hub: quay.io/konveyor/tackle2-hub:${{ inputs.version }}
         tackle_ui: quay.io/konveyor/tackle2-ui:${{ inputs.version }}
         addon_analyzer: quay.io/konveyor/tackle2-addon-analyzer:${{ inputs.version }}
+        addon_platform: quay.io/konveyor/tackle2-addon-platform:${{ inputs.version }}
         addon_discovery: quay.io/konveyor/tackle2-addon-discovery:${{ inputs.version }}
         provider_go: quay.io/konveyor/go-external-provider:${{ inputs.version }}
         provider_python: quay.io/konveyor/python-external-provider:${{ inputs.version }}
@@ -246,6 +227,66 @@ jobs:
         # Bundle specific args
         version: ${{ inputs.version }}
         channels: ${{ inputs.operator_channels }}
+
+    - name: Save prepared bundle
+      uses: actions/upload-artifact@v4
+      with:
+        name: prepared-bundle
+        overwrite: true
+        path: |
+          operator/bundle/
+          operator/bundle.Dockerfile
+
+  wait-for-images:
+    name: Wait for Release Images
+    needs: prepare-bundle
+    runs-on: ubuntu-latest
+    # Leave time for checkout/setup and the script's final timeout report.
+    timeout-minutes: 130
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.branch }}
+
+    - uses: actions/download-artifact@v4
+      with:
+        name: prepared-bundle
+        path: prepared
+
+    - name: Wait for all bundle images
+      run: |
+        make yq
+        ./bin/yq -r '[.metadata.annotations.containerImage, .spec.relatedImages[].image] | unique | .[]' \
+          prepared/bundle/manifests/konveyor-operator.clusterserviceversion.yaml > images.txt
+        python3 hack/wait-for-images.py images.txt --timeout 7200 --interval 180
+
+  build-bundle:
+    name: Build Bundle Manifest
+    needs: wait-for-images
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        path: operator
+        ref: ${{ inputs.branch }}
+
+    - uses: actions/download-artifact@v4
+      with:
+        name: prepared-bundle
+        path: operator
+
+    - name: Set up bundle tools
+      working-directory: ./operator
+      run: |
+        make yq
+        echo "$PWD/bin" >> "$GITHUB_PATH"
+
+    - name: Log in to Quay.io
+      uses: redhat-actions/podman-login@v1
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_PUBLISH_ROBOT }}
+        password: ${{ secrets.QUAY_PUBLISH_TOKEN }}
 
     - name: Replace with digest
       working-directory: ./operator

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -24,3 +24,22 @@ We use semantic versioning convention (semver) for stable releases, release bran
 1. Once the release PR is ready and merged, add it to the index image and push to quay.io
    1. `tools/push-release-metadata.py --old-version 1.9.9 --new-version 2.0.0`
    1. Create or refresh existing konveyor-tackle catalog source and validate `oc create -f konveyor-operator-catalog.yaml`
+
+## Retrying image readiness in the release workflow
+
+The **Create Release and Publish to Community Operators** workflow prepares bundle
+manifests, then runs **Wait for Release Images** (`wait-for-images`) before building
+and publishing the bundle image. The wait reads the operator image and all related
+images from the prepared manifests, so it checks the exact references the bundle
+will consume.
+
+Outstanding registry manifests are checked concurrently every three minutes, with
+one 120-minute deadline per attempt. Logs show newly available images, progress,
+and the remaining images with their last registry errors. Existing version tags
+count as ready; the workflow does not substitute older tags.
+
+If this job times out, resolve any upstream image-build failures and rerun
+**Wait for Release Images** from the workflow run. The retry reuses the prepared
+bundle artifact and starts a fresh wait budget without recreating successful
+component releases. Earlier waits required for dependent builds remain in
+`release-bases`.

--- a/hack/wait-for-images.py
+++ b/hack/wait-for-images.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Wait for registry manifests listed in a file, one image reference per line."""
+
+import argparse
+from concurrent.futures import ThreadPoolExecutor, as_completed
+import math
+from pathlib import Path
+import subprocess
+import time
+
+
+def inspect_image(image, timeout):
+    """Check the published tag without downloading image layers."""
+    try:
+        result = subprocess.run(
+            ["docker", "manifest", "inspect", image],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return f"Registry check timed out after {timeout:g}s"
+    except OSError as error:
+        return str(error)
+    if result.returncode:
+        return result.stderr.strip() or f"Registry check exited {result.returncode}"
+    return None
+
+
+def wait_for_images(images, timeout=7200, interval=180, probe_timeout=30):
+    pending = dict.fromkeys(images, "Not checked yet")
+    if not pending:
+        raise ValueError("Image list must not be empty")
+    total = len(pending)
+    started = time.monotonic()
+    deadline = started + timeout
+
+    with ThreadPoolExecutor(max_workers=total) as executor:
+        while pending:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            checks = {
+                executor.submit(inspect_image, image, min(probe_timeout, remaining)): image
+                for image in pending
+            }
+            for future in as_completed(checks):
+                image = checks[future]
+                error = future.result()
+                if error is None:
+                    del pending[image]
+                    print(f"Ready: {image}", flush=True)
+                else:
+                    pending[image] = error
+
+            elapsed = time.monotonic() - started
+            print(
+                f"{total - len(pending)}/{total} images ready; "
+                f"elapsed {elapsed:.0f}s / {timeout:g}s",
+                flush=True,
+            )
+            for image, error in pending.items():
+                print(f"Waiting: {image}: {error}", flush=True)
+            if not pending:
+                print("All release images are available.", flush=True)
+                return True
+            remaining = deadline - time.monotonic()
+            if remaining > 0:
+                time.sleep(min(interval, remaining))
+
+    print("Timed out waiting for release images:", flush=True)
+    for image, error in pending.items():
+        print(f"Missing: {image}: {error}", flush=True)
+    return False
+
+
+def positive_seconds(value):
+    seconds = float(value)
+    if not math.isfinite(seconds) or seconds <= 0:
+        raise argparse.ArgumentTypeError("Must be a positive, finite number of seconds")
+    return seconds
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("images", type=Path)
+    parser.add_argument("--timeout", type=positive_seconds, default=7200)
+    parser.add_argument("--interval", type=positive_seconds, default=180)
+    args = parser.parse_args()
+    images = [line.strip() for line in args.images.read_text().splitlines() if line.strip()]
+    if not images or any(image == "null" for image in images):
+        parser.error("Expected a nonempty list of image references")
+    return 0 if wait_for_images(images, args.timeout, args.interval) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/release/test_wait_for_images.py
+++ b/test/release/test_wait_for_images.py
@@ -1,0 +1,80 @@
+"""Run with python3 -m unittest discover -s test/release -v."""
+
+from contextlib import redirect_stdout
+import importlib.util
+import io
+from pathlib import Path
+import subprocess
+import sys
+import threading
+import time
+import unittest
+from unittest.mock import patch
+
+
+SCRIPT = Path(__file__).resolve().parents[2] / "hack/wait-for-images.py"
+SPEC = importlib.util.spec_from_file_location("wait_for_images", SCRIPT)
+waiter = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(waiter)
+
+
+class WaitForImagesTest(unittest.TestCase):
+    def test_checks_concurrently_and_retries_only_missing_images(self):
+        # Both first checks must start before either can finish.
+        barrier = threading.Barrier(2, timeout=2)
+        calls = {"published:v1": 0, "building:v1": 0}
+
+        def inspect(image, timeout):
+            calls[image] += 1
+            if calls[image] == 1:
+                barrier.wait()
+                if image == "building:v1":
+                    return "manifest unknown"
+            return None
+
+        output = io.StringIO()
+        with patch.object(waiter, "inspect_image", side_effect=inspect), redirect_stdout(output):
+            result = waiter.wait_for_images(list(calls), timeout=3, interval=0.01)
+        self.assertTrue(result)
+        self.assertEqual(calls, {"published:v1": 1, "building:v1": 2})
+        self.assertIn("1/2 images ready", output.getvalue())
+        self.assertIn("Waiting: building:v1: manifest unknown", output.getvalue())
+        self.assertIn("All release images are available", output.getvalue())
+
+    def test_shared_deadline_and_final_errors_for_every_missing_image(self):
+        output = io.StringIO()
+        started = time.monotonic()
+        with patch.object(waiter, "inspect_image", return_value="manifest unknown"), redirect_stdout(output):
+            result = waiter.wait_for_images(["one:v1", "two:v1"], timeout=0.1, interval=180)
+        self.assertFalse(result)
+        self.assertLess(time.monotonic() - started, 1)
+        self.assertIn("Missing: one:v1: manifest unknown", output.getvalue())
+        self.assertIn("Missing: two:v1: manifest unknown", output.getvalue())
+
+    def test_registry_requests_are_bounded_by_remaining_budget(self):
+        output = io.StringIO()
+        real_run = subprocess.run
+
+        def slow_registry(command, **kwargs):
+            return real_run([sys.executable, "-c", "import time; time.sleep(10)"], **kwargs)
+
+        started = time.monotonic()
+        with patch.object(waiter.subprocess, "run", side_effect=slow_registry) as run:
+            with redirect_stdout(output):
+                self.assertFalse(waiter.wait_for_images(["slow:v1"], timeout=0.1, interval=180))
+        self.assertLess(time.monotonic() - started, 1)
+        self.assertLessEqual(run.call_args.kwargs["timeout"], 0.1)
+        self.assertIn("Registry check timed out", output.getvalue())
+
+    def test_registry_errors_are_preserved(self):
+        result = subprocess.CompletedProcess([], 1, stderr="unauthorized: access denied\n")
+        with patch.object(waiter.subprocess, "run", return_value=result):
+            self.assertEqual(waiter.inspect_image("private:v1", 1), "unauthorized: access denied")
+
+    def test_empty_input_cannot_pass(self):
+        with self.assertRaisesRegex(ValueError, "must not be empty"):
+            waiter.wait_for_images([])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The release workflow could proceed when `skills` was published even though other agentic images were still building. This caused [the release job](https://github.com/konveyor/operator/actions/runs/34605448915/job/103302060353) to fail pulling `agent-base:v0.11.0-alpha.4`.

Add a dedicated `wait-for-images` job that reads every image reference from the prepared bundle manifests and checks outstanding version tags concurrently every three minutes. Each attempt has one 120-minute deadline, reports progress and unresolved registry errors, and accepts already-published version tags. Prepared bundle artifacts let the wait be rerun without recreating successful component releases; bundle image building depends on readiness succeeding. Existing waits needed by dependent builds remain.

Also supply the missing release-version override for the platform addon, so all 24 bundle images use the intended release tag.

Validation:
- Five regression tests pass, covering concurrency, retrying only missing images, shared deadlines, hung registry checks, error reporting, and empty input.
- Local bundle generation and validation confirmed all 24 image references match release inputs.
- Both optional bundle-build modes and the flattened project matrix validated.
- `git diff --check` passes. `actionlint` reports only three pre-existing issues: SC2129 and two outdated `create-pull-request@v5` references.
- Live release execution and GitHub job retries have not been exercised.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Release workflows can optionally skip bundle image builds and specify an add-on platform.
  - Added automated readiness checks that verify all required release images are available before bundle publication.
  - Image checks retry failed or unavailable requests until a shared timeout, with clear progress and error reporting.

- **Documentation**
  - Added guidance describing image readiness checks, retries, and bundle preparation during releases.

- **Tests**
  - Added coverage for retries, timeouts, concurrent checks, error reporting, and invalid input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->